### PR TITLE
Add 2FA endpoints

### DIFF
--- a/.cspell.json
+++ b/.cspell.json
@@ -12,6 +12,7 @@
     "Vodnjan",
     "aabe",
     "bpgk",
+    "chrono",
     "dtmf",
     "httpmock",
     "ibsso",
@@ -20,6 +21,8 @@
     "msisdn",
     "norun",
     "reqwest",
+    "rustc",
+    "thiserror",
     "xihiy",
     "yirml",
     "áéíø"

--- a/.cspell.json
+++ b/.cspell.json
@@ -3,8 +3,26 @@
   "$schema": "https://raw.githubusercontent.com/streetsidesoftware/cspell/master/cspell.schema.json",
   "language": "en",
   "words": [
+    "DTMF",
+    "ENROUTE",
+    "Istarska",
+    "MULTIPRODUCT",
+    "Multiproduct",
+    "Structs",
+    "Vodnjan",
+    "aabe",
+    "bpgk",
+    "dtmf",
+    "httpmock",
+    "ibsso",
+    "ijkl",
     "infobip",
-    "ibsso"
+    "msisdn",
+    "norun",
+    "reqwest",
+    "xihiy",
+    "yirml",
+    "áéíø"
   ],
   "flagWords": [],
   "patterns": [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ version = "0.4.0"
 [dependencies]
 dotenv = "0.15.0"
 lazy_static = "1.4"
-regex = "1.6"
+regex = "1.7"
 reqwest = { version = "0.11", features = ["blocking", "json", "multipart"] }
 serde = { version = "1.0", features = ["derive"] }
 serde_derive = "1.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ homepage = "https://www.infobip.com/"
 license = "MIT OR Apache-2.0"
 name = "infobip_sdk"
 repository = "https://github.com/infobip-community/infobip-api-rust-sdk"
-version = "0.4.0"
+version = "0.5.0"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,10 +12,11 @@ version = "0.4.0"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-dotenv = "0.15.0"
+cargo_metadata = "0.15"
 lazy_static = "1.4"
 regex = "1.7"
 reqwest = { version = "0.11", features = ["blocking", "json", "multipart"] }
+rustc_version = "0.4"
 serde = { version = "1.0", features = ["derive"] }
 serde_derive = "1.0"
 serde_json = "1.0"

--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
 # Infobip API Rust SDK
 
 ![Workflow](https://github.com/infobip-community/infobip-api-rust-sdk/actions/workflows/rust.yml/badge.svg)
-[![Licence](https://img.shields.io/github/license/infobip-community/infobip-api-rust-sdk)](LICENSE-MIT)
-[![Licence](https://img.shields.io/github/license/infobip-community/infobip-api-rust-sdk)](LICENSE-APACHE)
+[![License](https://img.shields.io/github/license/infobip-community/infobip-api-rust-sdk)](LICENSE-MIT)
+[![License](https://img.shields.io/github/license/infobip-community/infobip-api-rust-sdk)](LICENSE-APACHE)
 [![Crates.io](https://img.shields.io/crates/v/infobip_sdk)](https://crates.io/crates/infobip_sdk)
-![Crate downlads](https://img.shields.io/crates/d/rust_sdk)
+![Crate downloads](https://img.shields.io/crates/d/rust_sdk)
 
 Client SDK to use the Infobip API with pure Rust.
 
@@ -29,17 +29,16 @@ Then you can use your API Key and custom base URL to call the endpoints. You can
 do that, set the `IB_API_KEY` and `IB_BASE_URL` variables.
 
 ## 📦 Installation
-To install the library, run the following command from your project:
+To install the library, run the following command under your project's root directory:
 ```bash
 cargo add infobip_sdk
 ```
-
-Alternatively you can add the dependency to your project's `Cargo.toml`
+Alternatively, you can add the dependency to your project's `Cargo.toml`
 ```toml
 [dependencies]
 infobip_sdk = "<version>"
 ```
-Replace `<version>` with the latest (or desired) release of the library. For example `0.4.0`.
+Replace `<version>` with the latest (or desired) release of the library. For example `0.5.0`.
 
 ## 🚀 Usage
 To use the library, import the client and channel-specific models. Then create a client and
@@ -59,7 +58,7 @@ async fn main() {
 
     // Create a message.
     let mut message = Message::new(
-        vec![Destination::new("123456789012".to_string())]
+        vec![Destination::new("123456789012")]
     );
     message.text = Some("Your message text".to_string());
 
@@ -89,7 +88,7 @@ provided `new()` functions, with `serde_json::from_str()`, or with the true cons
 For example, to build a `Message` instance, you can do this:
 ```rust
 let mut message = Message::new(
-   vec![Destination::new("123456789012".to_string())]
+   vec![Destination::new("123456789012")]
 );
 message.text = Some("Your message text".to_string());
 ```
@@ -143,7 +142,7 @@ model.
 You can speed up compile time by turning only the needed channels as library features.
 For example, to only build SMS, add the dependency like this:
 ```toml
-infobip_sdk = { version = "0.3", features = ["sms"] }
+infobip_sdk = { version = "0.5", features = ["sms"] }
 ```
 You can see the complete list of features in the Cargo.toml of the project. Feature names
 follow channel names.

--- a/README.md
+++ b/README.md
@@ -8,33 +8,38 @@
 
 Client SDK to use the Infobip API with pure Rust.
 
-This crate enables you to use multiple Infobip communication channels, like SMS, MMS,
+This crate enables you to use multiple Infobip communication channels, like SMS, 2FA,
 WhatsApp, Email, etc. It abstracts the needed HTTP calls, models and validates payloads and
 models errors. The module structure is divided by communication channel.
 
 ---
 
 ## 📡 Supported Channels
-- [SMS](https://www.infobip.com/docs/api/channels/sms)
+Currently, we support the following channels:
+- [SMS + 2FA](https://www.infobip.com/docs/api/channels/sms)
 - [WhatsApp](https://www.infobip.com/docs/api/channels/whatsapp)
 - [Email](https://www.infobip.com/docs/api/channels/email)
 
-More Channels to be added in the near future!
+More channels to be added in the near future!
 
 ## 🔐 Authentication
 To use the library, you'll need to set up an [Infobip account](https://www.infobip.com/signup).
 Then you can use your API Key and custom base URL to call the endpoints. You can use the
 `Configuration::from_env_api_key()` method to load the configuration from the environment. To
-do that, set the `IB_API_KEY` and `IB_BASE_URL` variables. Alternatively, you can use the
-`Configuration::from_dotenv_api_key()` method to load the configuration from a `.env` file.
+do that, set the `IB_API_KEY` and `IB_BASE_URL` variables.
 
 ## 📦 Installation
-To use the library, add the dependency to your projects `Cargo.toml`
+To install the library, run the following command from your project:
+```bash
+cargo add infobip_sdk
+```
+
+Alternatively you can add the dependency to your project's `Cargo.toml`
 ```toml
 [dependencies]
 infobip_sdk = "<version>"
 ```
-Replace <version> is the latest (or desired) release of the library. For example `0.2.0`.
+Replace `<version>` with the latest (or desired) release of the library. For example `0.4.0`.
 
 ## 🚀 Usage
 To use the library, import the client and channel-specific models. Then create a client and

--- a/README.tpl
+++ b/README.tpl
@@ -1,10 +1,10 @@
 # Infobip API Rust SDK
 
 ![Workflow](https://github.com/infobip-community/infobip-api-rust-sdk/actions/workflows/rust.yml/badge.svg)
-[![Licence](https://img.shields.io/github/license/infobip-community/infobip-api-rust-sdk)](LICENSE-MIT)
-[![Licence](https://img.shields.io/github/license/infobip-community/infobip-api-rust-sdk)](LICENSE-APACHE)
+[![License](https://img.shields.io/github/license/infobip-community/infobip-api-rust-sdk)](LICENSE-MIT)
+[![License](https://img.shields.io/github/license/infobip-community/infobip-api-rust-sdk)](LICENSE-APACHE)
 [![Crates.io](https://img.shields.io/crates/v/infobip_sdk)](https://crates.io/crates/infobip_sdk)
-![Crate downlads](https://img.shields.io/crates/d/rust_sdk)
+![Crate downloads](https://img.shields.io/crates/d/rust_sdk)
 
 {{readme}}
 

--- a/src/api/email.rs
+++ b/src/api/email.rs
@@ -768,10 +768,7 @@ impl EmailClient {
     /// # Ok(())
     /// # }
     /// ```
-    pub async fn delete_domain(
-        &self,
-        domain_name: &str,
-    ) -> Result<reqwest::StatusCode, SdkError> {
+    pub async fn delete_domain(&self, domain_name: &str) -> Result<reqwest::StatusCode, SdkError> {
         let path = PATH_DELETE_DOMAIN.replace("{domainName}", domain_name);
 
         let response = send_no_body_request(
@@ -864,10 +861,7 @@ impl EmailClient {
     /// # Ok(())
     /// # }
     /// ```
-    pub async fn verify_domain(
-        &self,
-        domain_name: &str,
-    ) -> Result<reqwest::StatusCode, SdkError> {
+    pub async fn verify_domain(&self, domain_name: &str) -> Result<reqwest::StatusCode, SdkError> {
         let path = PATH_VERIFY_DOMAIN.replace("{domainName}", domain_name);
 
         let response = send_no_body_request(

--- a/src/api/email.rs
+++ b/src/api/email.rs
@@ -159,7 +159,7 @@ impl EmailClient {
     /// #
     /// # #[tokio::main]
     /// # async fn main() -> Result<(), Box<dyn std::error::Error>> {
-    /// let client = EmailClient::with_configuration(Configuration::from_dotenv_api_key()?);
+    /// let client = EmailClient::with_configuration(Configuration::from_env_api_key()?);
     ///
     /// let mut request_body = SendRequestBody::new("someone@domain.com".to_string());
     /// request_body.from = Some("someone@company.com".to_string());
@@ -213,7 +213,7 @@ impl EmailClient {
     /// #
     /// # #[tokio::main]
     /// # async fn main() -> Result<(), Box<dyn std::error::Error>> {
-    /// let client = EmailClient::with_configuration(Configuration::from_dotenv_api_key()?);
+    /// let client = EmailClient::with_configuration(Configuration::from_env_api_key()?);
     ///
     /// let query_parameters = GetBulksQueryParameters::new("some-bulk-id".to_string());
     ///
@@ -264,7 +264,7 @@ impl EmailClient {
     /// #
     /// # #[tokio::main]
     /// # async fn main() -> Result<(), Box<dyn std::error::Error>> {
-    /// let client = EmailClient::with_configuration(Configuration::from_dotenv_api_key()?);
+    /// let client = EmailClient::with_configuration(Configuration::from_env_api_key()?);
     ///
     /// let query_params = RescheduleQueryParameters::new("test-bulk-id-rust-003".to_string());
     /// let request_body = RescheduleRequestBody::new("2022-10-05T17:29:52Z".to_string());
@@ -318,7 +318,7 @@ impl EmailClient {
     /// #
     /// # #[tokio::main]
     /// # async fn main() -> Result<(), Box<dyn std::error::Error>> {
-    /// let client = EmailClient::with_configuration(Configuration::from_dotenv_api_key()?);
+    /// let client = EmailClient::with_configuration(Configuration::from_env_api_key()?);
     ///
     /// let query_params = GetScheduledStatusQueryParameters::new("some-bulk-id".to_string());
     ///
@@ -369,7 +369,7 @@ impl EmailClient {
     /// #
     /// # #[tokio::main]
     /// # async fn main() -> Result<(), Box<dyn std::error::Error>> {
-    /// let client = EmailClient::with_configuration(Configuration::from_dotenv_api_key()?);
+    /// let client = EmailClient::with_configuration(Configuration::from_env_api_key()?);
     ///
     /// let query_params = UpdateScheduledStatusQueryParameters::new("some-bulk-id".to_string());
     /// let request_body = UpdateScheduledStatusRequestBody::new(BulkStatus::CANCELED);
@@ -423,7 +423,7 @@ impl EmailClient {
     /// #
     /// # #[tokio::main]
     /// # async fn main() -> Result<(), Box<dyn std::error::Error>> {
-    /// let client = EmailClient::with_configuration(Configuration::from_dotenv_api_key()?);
+    /// let client = EmailClient::with_configuration(Configuration::from_env_api_key()?);
     ///
     /// let query_params = GetDeliveryReportsQueryParameters::default();
     ///
@@ -484,7 +484,7 @@ impl EmailClient {
     /// #
     /// # #[tokio::main]
     /// # async fn main() -> Result<(), Box<dyn std::error::Error>> {
-    /// let client = EmailClient::with_configuration(Configuration::from_dotenv_api_key()?);
+    /// let client = EmailClient::with_configuration(Configuration::from_env_api_key()?);
     ///
     /// let query_params = GetLogsQueryParameters::default();
     ///
@@ -559,7 +559,7 @@ impl EmailClient {
     /// #
     /// # #[tokio::main]
     /// # async fn main() -> Result<(), Box<dyn std::error::Error>> {
-    /// let client = EmailClient::with_configuration(Configuration::from_dotenv_api_key()?);
+    /// let client = EmailClient::with_configuration(Configuration::from_env_api_key()?);
     ///
     /// let request_body = ValidateAddressRequestBody::new("someone@somewhere.com".to_string());
     ///
@@ -608,7 +608,7 @@ impl EmailClient {
     /// #
     /// # #[tokio::main]
     /// # async fn main() -> Result<(), Box<dyn std::error::Error>> {
-    /// let client = EmailClient::with_configuration(Configuration::from_dotenv_api_key()?);
+    /// let client = EmailClient::with_configuration(Configuration::from_env_api_key()?);
     ///
     /// let query_params = GetDomainsQueryParameters::default();
     ///
@@ -666,7 +666,7 @@ impl EmailClient {
     /// #
     /// # #[tokio::main]
     /// # async fn main() -> Result<(), Box<dyn std::error::Error>> {
-    /// let client = EmailClient::with_configuration(Configuration::from_dotenv_api_key()?);
+    /// let client = EmailClient::with_configuration(Configuration::from_env_api_key()?);
     ///
     /// let request_body = AddDomainRequestBody::new("example.com".to_string());
     ///
@@ -714,7 +714,7 @@ impl EmailClient {
     /// #
     /// # #[tokio::main]
     /// # async fn main() -> Result<(), Box<dyn std::error::Error>> {
-    /// let client = EmailClient::with_configuration(Configuration::from_dotenv_api_key()?);
+    /// let client = EmailClient::with_configuration(Configuration::from_env_api_key()?);
     ///
     /// let response = client.get_domain("example.com".to_string()).await?;
     ///
@@ -760,7 +760,7 @@ impl EmailClient {
     /// #
     /// # #[tokio::main]
     /// # async fn main() -> Result<(), Box<dyn std::error::Error>> {
-    /// let client = EmailClient::with_configuration(Configuration::from_dotenv_api_key()?);
+    /// let client = EmailClient::with_configuration(Configuration::from_env_api_key()?);
     ///
     /// let status = client.delete_domain("example.com".to_string()).await?;
     ///
@@ -805,7 +805,7 @@ impl EmailClient {
     /// #
     /// # #[tokio::main]
     /// # async fn main() -> Result<(), Box<dyn std::error::Error>> {
-    /// let client = EmailClient::with_configuration(Configuration::from_dotenv_api_key()?);
+    /// let client = EmailClient::with_configuration(Configuration::from_env_api_key()?);
     ///
     /// let mut request_body = UpdateTrackingRequestBody::default();
     /// request_body.clicks = Some(true);
@@ -856,7 +856,7 @@ impl EmailClient {
     /// #
     /// # #[tokio::main]
     /// # async fn main() -> Result<(), Box<dyn std::error::Error>> {
-    /// let client = EmailClient::with_configuration(Configuration::from_dotenv_api_key()?);
+    /// let client = EmailClient::with_configuration(Configuration::from_env_api_key()?);
     ///
     /// let status = client.verify_domain("example.com".to_string()).await?;
     ///

--- a/src/api/email.rs
+++ b/src/api/email.rs
@@ -161,7 +161,7 @@ impl EmailClient {
     /// # async fn main() -> Result<(), Box<dyn std::error::Error>> {
     /// let client = EmailClient::with_configuration(Configuration::from_env_api_key()?);
     ///
-    /// let mut request_body = SendRequestBody::new("someone@domain.com".to_string());
+    /// let mut request_body = SendRequestBody::new("someone@domain.com");
     /// request_body.from = Some("someone@company.com".to_string());
     /// request_body.subject = Some("Test subject".to_string());
     /// request_body.text = Some("Hello world!".to_string());
@@ -215,7 +215,7 @@ impl EmailClient {
     /// # async fn main() -> Result<(), Box<dyn std::error::Error>> {
     /// let client = EmailClient::with_configuration(Configuration::from_env_api_key()?);
     ///
-    /// let query_parameters = GetBulksQueryParameters::new("some-bulk-id".to_string());
+    /// let query_parameters = GetBulksQueryParameters::new("some-bulk-id");
     ///
     /// let response = client.get_bulks(query_parameters).await?;
     ///
@@ -266,8 +266,8 @@ impl EmailClient {
     /// # async fn main() -> Result<(), Box<dyn std::error::Error>> {
     /// let client = EmailClient::with_configuration(Configuration::from_env_api_key()?);
     ///
-    /// let query_params = RescheduleQueryParameters::new("test-bulk-id-rust-003".to_string());
-    /// let request_body = RescheduleRequestBody::new("2022-10-05T17:29:52Z".to_string());
+    /// let query_params = RescheduleQueryParameters::new("test-bulk-id-rust-003");
+    /// let request_body = RescheduleRequestBody::new("2022-10-05T17:29:52Z");
     ///
     /// let response = client.reschedule(query_params, request_body).await?;
     ///
@@ -320,7 +320,7 @@ impl EmailClient {
     /// # async fn main() -> Result<(), Box<dyn std::error::Error>> {
     /// let client = EmailClient::with_configuration(Configuration::from_env_api_key()?);
     ///
-    /// let query_params = GetScheduledStatusQueryParameters::new("some-bulk-id".to_string());
+    /// let query_params = GetScheduledStatusQueryParameters::new("some-bulk-id");
     ///
     /// let response = client.get_scheduled_status(query_params).await?;
     ///
@@ -371,7 +371,7 @@ impl EmailClient {
     /// # async fn main() -> Result<(), Box<dyn std::error::Error>> {
     /// let client = EmailClient::with_configuration(Configuration::from_env_api_key()?);
     ///
-    /// let query_params = UpdateScheduledStatusQueryParameters::new("some-bulk-id".to_string());
+    /// let query_params = UpdateScheduledStatusQueryParameters::new("some-bulk-id");
     /// let request_body = UpdateScheduledStatusRequestBody::new(BulkStatus::CANCELED);
     ///
     /// let response = client.update_scheduled_status(query_params, request_body).await?;
@@ -561,7 +561,7 @@ impl EmailClient {
     /// # async fn main() -> Result<(), Box<dyn std::error::Error>> {
     /// let client = EmailClient::with_configuration(Configuration::from_env_api_key()?);
     ///
-    /// let request_body = ValidateAddressRequestBody::new("someone@somewhere.com".to_string());
+    /// let request_body = ValidateAddressRequestBody::new("someone@somewhere.com");
     ///
     /// let response = client.validate_address(request_body).await?;
     ///
@@ -668,7 +668,7 @@ impl EmailClient {
     /// # async fn main() -> Result<(), Box<dyn std::error::Error>> {
     /// let client = EmailClient::with_configuration(Configuration::from_env_api_key()?);
     ///
-    /// let request_body = AddDomainRequestBody::new("example.com".to_string());
+    /// let request_body = AddDomainRequestBody::new("example.com");
     ///
     /// let response = client.add_domain(request_body).await?;
     ///
@@ -716,7 +716,7 @@ impl EmailClient {
     /// # async fn main() -> Result<(), Box<dyn std::error::Error>> {
     /// let client = EmailClient::with_configuration(Configuration::from_env_api_key()?);
     ///
-    /// let response = client.get_domain("example.com".to_string()).await?;
+    /// let response = client.get_domain("example.com").await?;
     ///
     /// assert_eq!(response.status, StatusCode::OK);
     /// # Ok(())
@@ -724,9 +724,9 @@ impl EmailClient {
     /// ```
     pub async fn get_domain(
         &self,
-        domain_name: String,
+        domain_name: &str,
     ) -> Result<SdkResponse<GetDomainResponseBody>, SdkError> {
-        let path = PATH_GET_DOMAIN.replace("{domainName}", domain_name.as_str());
+        let path = PATH_GET_DOMAIN.replace("{domainName}", domain_name);
 
         let response = send_no_body_request(
             &self.client,
@@ -762,7 +762,7 @@ impl EmailClient {
     /// # async fn main() -> Result<(), Box<dyn std::error::Error>> {
     /// let client = EmailClient::with_configuration(Configuration::from_env_api_key()?);
     ///
-    /// let status = client.delete_domain("example.com".to_string()).await?;
+    /// let status = client.delete_domain("example.com").await?;
     ///
     /// assert_eq!(status, StatusCode::NO_CONTENT);
     /// # Ok(())
@@ -770,9 +770,9 @@ impl EmailClient {
     /// ```
     pub async fn delete_domain(
         &self,
-        domain_name: String,
+        domain_name: &str,
     ) -> Result<reqwest::StatusCode, SdkError> {
-        let path = PATH_DELETE_DOMAIN.replace("{domainName}", domain_name.as_str());
+        let path = PATH_DELETE_DOMAIN.replace("{domainName}", domain_name);
 
         let response = send_no_body_request(
             &self.client,
@@ -810,7 +810,7 @@ impl EmailClient {
     /// let mut request_body = UpdateTrackingRequestBody::default();
     /// request_body.clicks = Some(true);
     ///
-    /// let response = client.update_tracking("domain.com".to_string(), request_body).await?;
+    /// let response = client.update_tracking("domain.com", request_body).await?;
     ///
     /// assert_eq!(response.status, StatusCode::OK);
     /// # Ok(())
@@ -818,10 +818,10 @@ impl EmailClient {
     /// ```
     pub async fn update_tracking(
         &self,
-        domain_name: String,
+        domain_name: &str,
         request_body: UpdateTrackingRequestBody,
     ) -> Result<SdkResponse<UpdateTrackingResponseBody>, SdkError> {
-        let path = PATH_UPDATE_TRACKING.replace("{domainName}", domain_name.as_str());
+        let path = PATH_UPDATE_TRACKING.replace("{domainName}", domain_name);
 
         let response = send_valid_json_request(
             &self.client,
@@ -858,7 +858,7 @@ impl EmailClient {
     /// # async fn main() -> Result<(), Box<dyn std::error::Error>> {
     /// let client = EmailClient::with_configuration(Configuration::from_env_api_key()?);
     ///
-    /// let status = client.verify_domain("example.com".to_string()).await?;
+    /// let status = client.verify_domain("example.com").await?;
     ///
     /// assert_eq!(status, StatusCode::ACCEPTED);
     /// # Ok(())
@@ -866,9 +866,9 @@ impl EmailClient {
     /// ```
     pub async fn verify_domain(
         &self,
-        domain_name: String,
+        domain_name: &str,
     ) -> Result<reqwest::StatusCode, SdkError> {
-        let path = PATH_VERIFY_DOMAIN.replace("{domainName}", domain_name.as_str());
+        let path = PATH_VERIFY_DOMAIN.replace("{domainName}", domain_name);
 
         let response = send_no_body_request(
             &self.client,

--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -145,8 +145,7 @@ fn get_user_agent() -> Result<String, SdkError> {
         .exec()?
         .packages
         .into_iter()
-        .filter(|p| p.name == "infobip_sdk")
-        .next()
+        .find(|p| p.name == "infobip_sdk")
         .unwrap()
         .version;
 

--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -2,8 +2,10 @@
 use std::collections::HashMap;
 use std::fmt;
 
+use cargo_metadata::MetadataCommand;
 use reqwest;
 use reqwest::{RequestBuilder, Response, StatusCode};
+use rustc_version::version;
 use serde::Deserialize;
 use serde_derive::Serialize;
 use thiserror::Error;
@@ -37,6 +39,12 @@ pub enum SdkError {
 
     #[error("IO error")]
     Io(#[from] std::io::Error),
+
+    #[error("Rust version error")]
+    RustVersion(#[from] rustc_version::Error),
+
+    #[error("Cargo metadata error")]
+    CargoMetadata(#[from] cargo_metadata::Error),
 }
 
 /// Holds the status code and error details when a 4xx or 5xx response is received.
@@ -130,6 +138,40 @@ fn add_auth(mut builder: RequestBuilder, configuration: &Configuration) -> Reque
     builder
 }
 
+fn get_user_agent() -> Result<String, SdkError> {
+    let rust_version = version()?;
+    let cmd = MetadataCommand::new();
+    let package_version = cmd
+        .exec()?
+        .packages
+        .into_iter()
+        .filter(|p| p.name == "infobip_sdk")
+        .next()
+        .unwrap()
+        .version;
+
+    Ok(format!(
+        "@infobip/rust-sdk/{} rust/{}",
+        package_version, rust_version
+    ))
+}
+
+// Adds user agent to the request builder. Synchronous version.
+fn add_user_agent(mut builder: RequestBuilder) -> Result<RequestBuilder, SdkError> {
+    builder = builder.header("User-Agent", get_user_agent()?);
+
+    Ok(builder)
+}
+
+// Adds user agent to the request builder. Synchronous version.
+fn add_user_agent_blocking(
+    mut builder: reqwest::blocking::RequestBuilder,
+) -> Result<reqwest::blocking::RequestBuilder, SdkError> {
+    builder = builder.header("User-Agent", get_user_agent()?);
+
+    Ok(builder)
+}
+
 // Blocking version of add_auth, uses blocking request builder.
 fn add_auth_blocking(
     mut builder: reqwest::blocking::RequestBuilder,
@@ -167,6 +209,7 @@ async fn send_no_body_request(
     let mut builder = client.request(method, url).query(&query_parameters);
 
     builder = add_auth(builder, configuration);
+    builder = add_user_agent(builder)?;
 
     Ok(builder.send().await?)
 }
@@ -188,6 +231,7 @@ async fn send_valid_json_request<T: Validate + serde::Serialize>(
         .query(&query_parameters);
 
     builder = add_auth(builder, configuration);
+    builder = add_user_agent(builder)?;
 
     Ok(builder.send().await?)
 }
@@ -203,6 +247,7 @@ async fn send_multipart_request(
     let mut builder = client.request(method, url);
 
     builder = add_auth(builder, configuration);
+    builder = add_user_agent(builder)?;
 
     Ok(builder.multipart(form).send().await?)
 }
@@ -220,6 +265,7 @@ fn send_blocking_valid_json_request<T: Validate + serde::Serialize>(
     let mut builder = client.request(method, url);
 
     builder = add_auth_blocking(builder, configuration);
+    builder = add_user_agent_blocking(builder)?;
 
     Ok(builder.json(&request_body).send()?)
 }

--- a/src/api/sms.rs
+++ b/src/api/sms.rs
@@ -19,15 +19,16 @@ use crate::model::sms::{
     GetTfaMessageTemplateResponseBody, GetTfaMessageTemplatesResponseBody,
     GetTfaVerificationStatusQueryParameters, GetTfaVerificationStatusResponseBody,
     RescheduleQueryParameters, RescheduleRequestBody, RescheduleResponseBody,
-    ResendPinOverSmsRequestBody, ResendPinOverSmsResponseBody, SendBinaryRequestBody,
-    SendBinaryResponseBody, SendOverQueryParametersQueryParameters,
-    SendOverQueryParametersResponseBody, SendPinOverSmsQueryParameters, SendPinOverSmsRequestBody,
-    SendPinOverSmsResponseBody, SendPinOverVoiceRequestBody, SendPinOverVoiceResponseBody,
-    SendRequestBody, SendResponseBody, UpdateScheduledStatusQueryParameters,
-    UpdateScheduledStatusRequestBody, UpdateScheduledStatusResponseBody,
-    UpdateTfaApplicationRequestBody, UpdateTfaApplicationResponseBody,
-    UpdateTfaMessageTemplateRequestBody, UpdateTfaMessageTemplateResponseBody,
-    VerifyPhoneNumberRequestBody, VerifyPhoneNumberResponseBody,
+    ResendPinOverSmsRequestBody, ResendPinOverSmsResponseBody, ResendPinOverVoiceRequestBody,
+    ResendPinOverVoiceResponseBody, SendBinaryRequestBody, SendBinaryResponseBody,
+    SendOverQueryParametersQueryParameters, SendOverQueryParametersResponseBody,
+    SendPinOverSmsQueryParameters, SendPinOverSmsRequestBody, SendPinOverSmsResponseBody,
+    SendPinOverVoiceRequestBody, SendPinOverVoiceResponseBody, SendRequestBody, SendResponseBody,
+    UpdateScheduledStatusQueryParameters, UpdateScheduledStatusRequestBody,
+    UpdateScheduledStatusResponseBody, UpdateTfaApplicationRequestBody,
+    UpdateTfaApplicationResponseBody, UpdateTfaMessageTemplateRequestBody,
+    UpdateTfaMessageTemplateResponseBody, VerifyPhoneNumberRequestBody,
+    VerifyPhoneNumberResponseBody,
 };
 use crate::{
     configuration::Configuration,
@@ -56,6 +57,7 @@ pub const PATH_UPDATE_TFA_MESSAGE_TEMPLATE: &str = "/2fa/2/applications/{appId}/
 pub const PATH_SEND_PIN_OVER_SMS: &str = "/2fa/2/pin";
 pub const PATH_RESEND_PIN_OVER_SMS: &str = "/2fa/2/pin/{pinId}/resend";
 pub const PATH_SEND_PIN_OVER_VOICE: &str = "/2fa/2/pin/voice";
+pub const PATH_RESEND_PIN_OVER_VOICE: &str = "/2fa/2/pin/{pinId}/resend/voice";
 pub const PATH_VERIFY_PHONE_NUMBER: &str = "/2fa/2/pin/{pinId}/verify";
 pub const PATH_GET_TFA_VERIFICATION_STATUS: &str = "/2fa/2/applications/{appId}/verifications";
 
@@ -869,7 +871,7 @@ impl SmsClient {
 
     /// Get a single 2FA application to see its configuration details.
     /// # Example
-    /// ```rust
+    /// ```norun
     /// # use infobip_sdk::api::sms::SmsClient;
     /// # use infobip_sdk::configuration::Configuration;
     /// # use reqwest::StatusCode;
@@ -915,7 +917,7 @@ impl SmsClient {
 
     /// Change configuration options for your existing 2FA application.
     /// # Example
-    /// ```rust
+    /// ```norun
     /// # use infobip_sdk::api::sms::SmsClient;
     /// # use infobip_sdk::configuration::Configuration;
     /// # use infobip_sdk::model::sms::UpdateTfaApplicationRequestBody;
@@ -965,7 +967,7 @@ impl SmsClient {
 
     /// Get all message templates in a 2FA application.
     /// # Example
-    /// ```rust
+    /// ```norun
     /// # use infobip_sdk::api::sms::SmsClient;
     /// # use infobip_sdk::configuration::Configuration;
     /// # use reqwest::StatusCode;
@@ -1011,7 +1013,7 @@ impl SmsClient {
 
     /// Create one or more message templates where your PIN will be dynamically included when you send the PIN message.
     /// # Example
-    /// ```rust
+    /// ```norun
     /// # use infobip_sdk::api::sms::SmsClient;
     /// # use infobip_sdk::configuration::Configuration;
     /// # use infobip_sdk::model::sms::CreateTfaMessageTemplateRequestBody;
@@ -1061,7 +1063,7 @@ impl SmsClient {
 
     /// Get a single 2FA message template from an application to see its configuration details.
     /// # Example
-    /// ```rust
+    /// ```norun
     /// # use infobip_sdk::api::sms::SmsClient;
     /// # use infobip_sdk::configuration::Configuration;
     /// # use reqwest::StatusCode;
@@ -1085,7 +1087,7 @@ impl SmsClient {
     ) -> Result<SdkResponse<GetTfaMessageTemplateResponseBody>, SdkError> {
         let path = &PATH_GET_TFA_MESSAGE_TEMPLATE
             .replace("{appId}", application_id)
-            .replace("{templateId}", template_id);
+            .replace("{msgId}", template_id);
 
         let response = send_no_body_request(
             &self.client,
@@ -1111,7 +1113,7 @@ impl SmsClient {
 
     /// Change configuration options for your existing 2FA application message template.
     /// # Example
-    /// ```rust
+    /// ```norun
     /// # use infobip_sdk::api::sms::SmsClient;
     /// # use infobip_sdk::configuration::Configuration;
     /// # use infobip_sdk::model::sms::UpdateTfaMessageTemplateRequestBody;
@@ -1166,7 +1168,7 @@ impl SmsClient {
 
     /// Send a PIN code over SMS using a previously created message template.
     /// # Example
-    /// ```rust
+    /// ```norun
     /// # use infobip_sdk::api::sms::SmsClient;
     /// # use infobip_sdk::configuration::Configuration;
     /// # use infobip_sdk::model::sms::SendPinOverSmsQueryParameters;
@@ -1222,7 +1224,7 @@ impl SmsClient {
 
     /// Resend the same (previously sent) PIN code over SMS.
     /// # Example
-    /// ```rust
+    /// ```norun
     /// # use infobip_sdk::api::sms::SmsClient;
     /// # use infobip_sdk::configuration::Configuration;
     /// # use infobip_sdk::model::sms::ResendPinOverSmsRequestBody;
@@ -1273,7 +1275,7 @@ impl SmsClient {
 
     /// Send a PIN code over Voice using previously created message template.
     /// # Example
-    /// ```rust
+    /// ```norun
     /// # use infobip_sdk::api::sms::SmsClient;
     /// # use infobip_sdk::configuration::Configuration;
     /// # use infobip_sdk::model::sms::SendPinOverVoiceRequestBody;
@@ -1318,9 +1320,60 @@ impl SmsClient {
         }
     }
 
+    /// Resend the same (previously sent) PIN code over Voice.
+    /// # Example
+    /// ```no_run
+    /// # use infobip_sdk::api::sms::SmsClient;
+    /// # use infobip_sdk::configuration::Configuration;
+    /// # use infobip_sdk::model::sms::ResendPinOverVoiceRequestBody;
+    /// # use reqwest::StatusCode;
+    /// #
+    /// # #[tokio::main]
+    /// # async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    /// let client = SmsClient::with_configuration(Configuration::from_env_api_key()?);
+    ///
+    /// let pin_id = "02CC3CAAFD733136AA15DFAC720A0C42";
+    /// let request_body = ResendPinOverVoiceRequestBody::default();
+    ///
+    /// let response = client.resend_pin_over_voice(pin_id, request_body).await?;
+    ///
+    /// assert_eq!(response.status, StatusCode::OK);
+    /// # Ok(())
+    /// # }
+    /// ```
+    pub async fn resend_pin_over_voice(
+        &self,
+        pin_id: &str,
+        request_body: ResendPinOverVoiceRequestBody,
+    ) -> Result<SdkResponse<ResendPinOverVoiceResponseBody>, SdkError> {
+        let path = &PATH_RESEND_PIN_OVER_VOICE.replace("{pinId}", pin_id);
+
+        let response = send_valid_json_request(
+            &self.client,
+            &self.configuration,
+            request_body,
+            HashMap::new(),
+            reqwest::Method::POST,
+            path,
+        )
+        .await?;
+
+        let status = response.status();
+        let text = response.text().await?;
+
+        if status.is_success() {
+            Ok(SdkResponse {
+                body: serde_json::from_str(&text)?,
+                status,
+            })
+        } else {
+            Err(build_api_error(status, &text))
+        }
+    }
+
     /// Verify a phone number to confirm successful 2FA authentication.
     /// # Example
-    /// ```rust
+    /// ```norun
     /// # use infobip_sdk::api::sms::SmsClient;
     /// # use infobip_sdk::configuration::Configuration;
     /// # use infobip_sdk::model::sms::VerifyPhoneNumberRequestBody;
@@ -1371,7 +1424,7 @@ impl SmsClient {
 
     /// Check if a phone number is already verified for a specific 2FA application.
     /// # Example
-    /// ```rust
+    /// ```norun
     /// # use infobip_sdk::api::sms::SmsClient;
     /// # use infobip_sdk::configuration::Configuration;
     /// # use infobip_sdk::model::sms::{GetTfaVerificationStatusQueryParameters,

--- a/src/api/sms.rs
+++ b/src/api/sms.rs
@@ -92,7 +92,7 @@ impl SmsClient {
     /// # async fn main() -> Result<(), Box<dyn std::error::Error>> {
     /// let sms_client = SmsClient::with_configuration(Configuration::from_env_api_key()?);
     ///
-    /// let mut request_body = PreviewRequestBody::new("Some text to preview".to_string());
+    /// let mut request_body = PreviewRequestBody::new("Some text to preview");
     /// request_body.transliteration = Some("GREEK".to_string());
     ///
     /// let response = sms_client.preview(request_body).await?;
@@ -211,7 +211,7 @@ impl SmsClient {
     /// # async fn main() -> Result<(), Box<dyn std::error::Error>> {
     /// let sms_client = SmsClient::with_configuration(Configuration::from_env_api_key()?);
     ///
-    /// let mut message = Message::new(vec![Destination::new("555555555555".to_string())]);
+    /// let mut message = Message::new(vec![Destination::new("555555555555")]);
     /// message.text = Some("Hello Rustacean!".to_string());
     /// message.from = Some("Infobip".to_string());
     ///
@@ -263,8 +263,8 @@ impl SmsClient {
     /// # async fn main() -> Result<(), Box<dyn std::error::Error>> {
     /// let sms_client = SmsClient::with_configuration(Configuration::from_env_api_key()?);
     ///
-    /// let mut message = BinaryMessage::new(vec![Destination::new("555555555555".to_string())]);
-    /// message.binary = Some(BinaryData::new("0f c2 4a bf 34 13 ba".to_string()));
+    /// let mut message = BinaryMessage::new(vec![Destination::new("555555555555")]);
+    /// message.binary = Some(BinaryData::new("0f c2 4a bf 34 13 ba"));
     ///
     /// let request_body = SendBinaryRequestBody::new(vec![message]);
     ///
@@ -315,7 +315,7 @@ impl SmsClient {
     /// # async fn main() -> Result<(), Box<dyn std::error::Error>> {
     /// let sms_client = SmsClient::with_configuration(Configuration::from_env_api_key()?);
     ///
-    /// let query_parameters = GetScheduledQueryParameters::new("dummy-bulk-id".to_string());
+    /// let query_parameters = GetScheduledQueryParameters::new("dummy-bulk-id");
     ///
     /// let response = sms_client.get_scheduled(query_parameters).await?;
     ///
@@ -510,8 +510,8 @@ impl SmsClient {
     ///
     /// let destinations = vec!["31612345678".to_string(), "31698765432".to_string()];
     /// let query_parameters = SendOverQueryParametersQueryParameters::new(
-    ///     "username".to_string(),
-    ///     "password".to_string(),
+    ///     "username",
+    ///     "password",
     ///     destinations
     /// );
     ///
@@ -631,8 +631,8 @@ impl SmsClient {
     /// # async fn main() -> Result<(), Box<dyn std::error::Error>> {
     /// let sms_client = SmsClient::with_configuration(Configuration::from_env_api_key()?);
     ///
-    /// let query_parameters = RescheduleQueryParameters::new("some-bulk-id".to_string());
-    /// let request_body = RescheduleRequestBody::new("2020-01-01T00:00:00".to_string());
+    /// let query_parameters = RescheduleQueryParameters::new("some-bulk-id");
+    /// let request_body = RescheduleRequestBody::new("2020-01-01T00:00:00");
     ///
     /// let response = sms_client.reschedule(query_parameters, request_body).await?;
     ///
@@ -686,7 +686,7 @@ impl SmsClient {
     /// # async fn main() -> Result<(), Box<dyn std::error::Error>> {
     /// let sms_client = SmsClient::with_configuration(Configuration::from_env_api_key()?);
     ///
-    /// let query_parameters = GetScheduledStatusQueryParameters::new("some-bulk-id".to_string());
+    /// let query_parameters = GetScheduledStatusQueryParameters::new("some-bulk-id");
     ///
     /// let response = sms_client.get_scheduled_status(query_parameters).await?;
     ///
@@ -739,7 +739,7 @@ impl SmsClient {
     /// # async fn main() -> Result<(), Box<dyn std::error::Error>> {
     /// let sms_client = SmsClient::with_configuration(Configuration::from_env_api_key()?);
     ///
-    /// let query_parameters = UpdateScheduledStatusQueryParameters::new("some-bulk-id".to_string());
+    /// let query_parameters = UpdateScheduledStatusQueryParameters::new("some-bulk-id");
     /// let request_body = UpdateScheduledStatusRequestBody::new(ScheduledStatus::CANCELED);
     ///
     /// let response = sms_client.update_scheduled_status(query_parameters, request_body).await?;
@@ -835,7 +835,7 @@ impl SmsClient {
     /// # #[tokio::main]
     /// # async fn main() -> Result<(), Box<dyn std::error::Error>> {
     /// let client = SmsClient::with_configuration(Configuration::from_env_api_key()?);
-    /// let request_body = CreateTfaApplicationRequestBody::new("some-name".to_string());
+    /// let request_body = CreateTfaApplicationRequestBody::new("some-name");
     ///
     /// let response = client.create_tfa_application(request_body).await?;
     ///

--- a/src/api/tests/email.rs
+++ b/src/api/tests/email.rs
@@ -47,7 +47,7 @@ async fn test_send_valid() {
 
     let client = EmailClient::with_configuration(get_test_configuration(&server.base_url()));
 
-    let request_body = SendRequestBody::new("some@mail.com".to_string());
+    let request_body = SendRequestBody::new("some@mail.com");
 
     let response = client.send(request_body).await.unwrap();
 
@@ -59,7 +59,7 @@ async fn test_send_valid() {
 async fn test_send_invalid_request() {
     let client = EmailClient::with_configuration(get_test_configuration(DUMMY_BASE_URL));
 
-    let request_body = SendRequestBody::new("".to_string());
+    let request_body = SendRequestBody::new("");
 
     let error = client.send(request_body).await.unwrap_err();
 
@@ -94,7 +94,7 @@ async fn test_get_bulks_valid() {
 
     let client = EmailClient::with_configuration(get_test_configuration(&server.base_url()));
 
-    let query_params = GetBulksQueryParameters::new("bulk-id".to_string());
+    let query_params = GetBulksQueryParameters::new("bulk-id");
 
     let response = client.get_bulks(query_params).await.unwrap();
 
@@ -106,7 +106,7 @@ async fn test_get_bulks_valid() {
 async fn get_bulks_invalid() {
     let client = EmailClient::with_configuration(get_test_configuration(DUMMY_BASE_URL));
 
-    let query_params = GetBulksQueryParameters::new("".to_string());
+    let query_params = GetBulksQueryParameters::new("");
 
     let error = client.get_bulks(query_params).await.unwrap_err();
 
@@ -136,8 +136,8 @@ async fn reschedule_valid() {
 
     let client = EmailClient::with_configuration(get_test_configuration(&server.base_url()));
 
-    let query_parameters = RescheduleQueryParameters::new("bulk-id".to_string());
-    let request_body = RescheduleRequestBody::new("2022-10-03T20:27:41Z".to_string());
+    let query_parameters = RescheduleQueryParameters::new("bulk-id");
+    let request_body = RescheduleRequestBody::new("2022-10-03T20:27:41Z");
 
     let response = client
         .reschedule(query_parameters, request_body)
@@ -151,8 +151,8 @@ async fn reschedule_valid() {
 async fn reschedule_no_bulk_id() {
     let client = EmailClient::with_configuration(get_test_configuration(DUMMY_BASE_URL));
 
-    let query_parameters = RescheduleQueryParameters::new("".to_string());
-    let request_body = RescheduleRequestBody::new("2022-10-03T20:27:41Z".to_string());
+    let query_parameters = RescheduleQueryParameters::new("");
+    let request_body = RescheduleRequestBody::new("2022-10-03T20:27:41Z");
 
     let error = client
         .reschedule(query_parameters, request_body)
@@ -190,7 +190,7 @@ async fn get_scheduled_status_valid() {
 
     let client = EmailClient::with_configuration(get_test_configuration(&server.base_url()));
 
-    let query_parameters = GetScheduledStatusQueryParameters::new("bulk-id".to_string());
+    let query_parameters = GetScheduledStatusQueryParameters::new("bulk-id");
 
     let response = client.get_scheduled_status(query_parameters).await.unwrap();
 
@@ -216,7 +216,7 @@ async fn update_scheduled_status_valid() {
 
     let client = EmailClient::with_configuration(get_test_configuration(&server.base_url()));
 
-    let query_parameters = UpdateScheduledStatusQueryParameters::new("bulk-id".to_string());
+    let query_parameters = UpdateScheduledStatusQueryParameters::new("bulk-id");
     let request_body = UpdateScheduledStatusRequestBody::new(BulkStatus::CANCELED);
 
     let response = client
@@ -353,7 +353,7 @@ async fn validate_address_valid() {
 
     let client = EmailClient::with_configuration(get_test_configuration(&server.base_url()));
 
-    let request_body = ValidateAddressRequestBody::new("address@email.com".to_string());
+    let request_body = ValidateAddressRequestBody::new("address@email.com");
 
     let response = client.validate_address(request_body).await.unwrap();
 
@@ -447,7 +447,7 @@ async fn add_domain_valid() {
 
     let client = EmailClient::with_configuration(get_test_configuration(&server.base_url()));
 
-    let request_body = AddDomainRequestBody::new("domain.com".to_string());
+    let request_body = AddDomainRequestBody::new("domain.com");
 
     let response = client.add_domain(request_body).await.unwrap();
 
@@ -479,8 +479,8 @@ async fn get_domain_valid() {
     }
     "#;
 
-    let domain_name = "newDomain.com".to_string();
-    let path = PATH_GET_DOMAIN.replace("{domainName}", domain_name.as_str());
+    let domain_name = "newDomain.com";
+    let path = PATH_GET_DOMAIN.replace("{domainName}", domain_name);
 
     let server = mock_json_endpoint(
         httpmock::Method::GET,
@@ -492,15 +492,15 @@ async fn get_domain_valid() {
 
     let client = EmailClient::with_configuration(get_test_configuration(&server.base_url()));
 
-    let response = client.get_domain(domain_name.to_string()).await.unwrap();
+    let response = client.get_domain(domain_name).await.unwrap();
 
     assert_eq!(response.status, reqwest::StatusCode::OK);
 }
 
 #[tokio::test]
 async fn delete_domain_valid() {
-    let domain_name = "newDomain.com".to_string();
-    let path = PATH_DELETE_DOMAIN.replace("{domainName}", domain_name.as_str());
+    let domain_name = "newDomain.com";
+    let path = PATH_DELETE_DOMAIN.replace("{domainName}", domain_name);
 
     let server = mock_json_endpoint(
         httpmock::Method::DELETE,
@@ -512,7 +512,7 @@ async fn delete_domain_valid() {
 
     let client = EmailClient::with_configuration(get_test_configuration(&server.base_url()));
 
-    let status = client.delete_domain(domain_name.to_string()).await.unwrap();
+    let status = client.delete_domain(domain_name).await.unwrap();
 
     assert_eq!(status, reqwest::StatusCode::NO_CONTENT);
 }
@@ -542,8 +542,8 @@ async fn update_tracking_valid() {
     }
     "#;
 
-    let domain_name = "newDomain.com".to_string();
-    let path = PATH_UPDATE_TRACKING.replace("{domainName}", domain_name.as_str());
+    let domain_name = "newDomain.com";
+    let path = PATH_UPDATE_TRACKING.replace("{domainName}", domain_name);
 
     let server = mock_json_endpoint(
         httpmock::Method::PUT,
@@ -558,7 +558,7 @@ async fn update_tracking_valid() {
     let request_body = UpdateTrackingRequestBody::default();
 
     let response = client
-        .update_tracking(domain_name.to_string(), request_body)
+        .update_tracking(domain_name, request_body)
         .await
         .unwrap();
 
@@ -567,8 +567,8 @@ async fn update_tracking_valid() {
 
 #[tokio::test]
 async fn verify_domain_valid() {
-    let domain_name = "newDomain.com".to_string();
-    let path = PATH_VERIFY_DOMAIN.replace("{domainName}", domain_name.as_str());
+    let domain_name = "newDomain.com";
+    let path = PATH_VERIFY_DOMAIN.replace("{domainName}", domain_name);
 
     let server = mock_json_endpoint(
         httpmock::Method::POST,
@@ -580,7 +580,7 @@ async fn verify_domain_valid() {
 
     let client = EmailClient::with_configuration(get_test_configuration(&server.base_url()));
 
-    let status = client.verify_domain(domain_name.to_string()).await.unwrap();
+    let status = client.verify_domain(domain_name).await.unwrap();
 
     assert_eq!(status, reqwest::StatusCode::ACCEPTED);
 }

--- a/src/api/tests/sms.rs
+++ b/src/api/tests/sms.rs
@@ -34,7 +34,7 @@ async fn test_preview_valid() {
 
     let client = SmsClient::with_configuration(get_test_configuration(&server.base_url()));
 
-    let request_body = PreviewRequestBody::new(DUMMY_TEXT.to_string());
+    let request_body = PreviewRequestBody::new(DUMMY_TEXT);
 
     let response = client.preview(request_body).await.unwrap();
 
@@ -47,8 +47,8 @@ async fn test_preview_valid() {
 async fn test_preview_bad_request() {
     let client = SmsClient::with_configuration(get_test_configuration(DUMMY_BASE_URL));
 
-    let mut request_body = PreviewRequestBody::new(DUMMY_TEXT.to_string());
-    request_body.language_code = Some("XX".to_string());
+    let mut request_body = PreviewRequestBody::new(DUMMY_TEXT);
+    request_body.language_code = Some("XX".into());
 
     let error = client.preview(request_body).await.unwrap_err();
 
@@ -85,7 +85,7 @@ fn test_blocking_preview_valid() {
     let client =
         BlockingSmsClient::with_configuration(get_test_configuration(&mock_server.base_url()));
 
-    let request_body = PreviewRequestBody::new(DUMMY_TEXT.to_string());
+    let request_body = PreviewRequestBody::new(DUMMY_TEXT);
 
     let response = client.preview(request_body).unwrap();
 
@@ -118,7 +118,7 @@ async fn test_preview_server_error() {
 
     let client = SmsClient::with_configuration(get_test_configuration(&server.base_url()));
 
-    let request_body = PreviewRequestBody::new(DUMMY_TEXT.to_string());
+    let request_body = PreviewRequestBody::new(DUMMY_TEXT);
 
     let error = client.preview(request_body).await.unwrap_err();
     if let SdkError::ApiRequestError(api_error) = error {
@@ -281,7 +281,7 @@ async fn test_send_valid() {
 
     let client = SmsClient::with_configuration(get_test_configuration(&server.base_url()));
 
-    let message = Message::new(vec![Destination::new("123456789101".to_string())]);
+    let message = Message::new(vec![Destination::new("123456789101")]);
     let request_body = SendRequestBody::new(vec![message]);
 
     let response = client.send(request_body).await.unwrap();
@@ -332,7 +332,7 @@ async fn test_send_binary_valid() {
 
     let client = SmsClient::with_configuration(get_test_configuration(&server.base_url()));
 
-    let message = BinaryMessage::new(vec![Destination::new("123456789101".to_string())]);
+    let message = BinaryMessage::new(vec![Destination::new("123456789101")]);
     let request_body = SendBinaryRequestBody::new(vec![message]);
 
     let response = client.send_binary(request_body).await.unwrap();
@@ -373,8 +373,8 @@ async fn test_send_over_query_parameters_valid() {
     let client = SmsClient::with_configuration(get_test_configuration(&server.base_url()));
 
     let query_parameters = SendOverQueryParametersQueryParameters::new(
-        "username".to_string(),
-        "password".to_string(),
+        "username",
+        "password",
         vec!["41793026727".to_string()],
     );
 
@@ -406,7 +406,7 @@ async fn test_get_scheduled_valid() {
 
     let client = SmsClient::with_configuration(get_test_configuration(&server.base_url()));
 
-    let query_parameters = GetScheduledQueryParameters::new("BULK-ID-123-xyz".to_string());
+    let query_parameters = GetScheduledQueryParameters::new("BULK-ID-123-xyz");
 
     let response = client.get_scheduled(query_parameters).await.unwrap();
 
@@ -418,7 +418,7 @@ async fn test_get_scheduled_valid() {
 async fn test_get_scheduled_empty_bulk_id() {
     let client = SmsClient::with_configuration(get_test_configuration("https://some.url"));
 
-    let query_parameters = GetScheduledQueryParameters::new("".to_string());
+    let query_parameters = GetScheduledQueryParameters::new("");
 
     assert!(client.get_scheduled(query_parameters).await.is_err());
 }
@@ -442,8 +442,8 @@ async fn test_reschedule_valid() {
 
     let client = SmsClient::with_configuration(get_test_configuration(&server.base_url()));
 
-    let query_parameters = RescheduleQueryParameters::new("BULK-ID-123-xyz".to_string());
-    let request_body = RescheduleRequestBody::new("2021-08-25T16:00:00.000+0000".to_string());
+    let query_parameters = RescheduleQueryParameters::new("BULK-ID-123-xyz");
+    let request_body = RescheduleRequestBody::new("2021-08-25T16:00:00.000+0000");
 
     let response = client
         .reschedule(query_parameters, request_body)
@@ -459,8 +459,8 @@ async fn test_reschedule_valid() {
 async fn test_reschedule_empty_bulk_id() {
     let client = SmsClient::with_configuration(get_test_configuration("https://some.url"));
 
-    let query_parameters = RescheduleQueryParameters::new("".to_string());
-    let request_body = RescheduleRequestBody::new("2021-08-25T16:00:00.000+0000".to_string());
+    let query_parameters = RescheduleQueryParameters::new("");
+    let request_body = RescheduleRequestBody::new("2021-08-25T16:00:00.000+0000");
 
     assert!(client
         .reschedule(query_parameters, request_body)
@@ -472,8 +472,8 @@ async fn test_reschedule_empty_bulk_id() {
 async fn test_reschedule_empty_send_at() {
     let client = SmsClient::with_configuration(get_test_configuration("https://some.url"));
 
-    let query_parameters = RescheduleQueryParameters::new("BULK-ID-123-xyz".to_string());
-    let request_body = RescheduleRequestBody::new("".to_string());
+    let query_parameters = RescheduleQueryParameters::new("BULK-ID-123-xyz");
+    let request_body = RescheduleRequestBody::new("");
 
     assert!(client
         .reschedule(query_parameters, request_body)
@@ -500,7 +500,7 @@ async fn test_get_scheduled_status_valid() {
 
     let client = SmsClient::with_configuration(get_test_configuration(&server.base_url()));
 
-    let query_parameters = GetScheduledStatusQueryParameters::new("BULK-ID-123-xyz".to_string());
+    let query_parameters = GetScheduledStatusQueryParameters::new("BULK-ID-123-xyz");
 
     let response = client.get_scheduled_status(query_parameters).await.unwrap();
 
@@ -513,7 +513,7 @@ async fn test_get_scheduled_status_valid() {
 async fn test_get_scheduled_status_empty_bulk_id() {
     let client = SmsClient::with_configuration(get_test_configuration("https://some.url"));
 
-    let query_parameters = GetScheduledStatusQueryParameters::new("".to_string());
+    let query_parameters = GetScheduledStatusQueryParameters::new("");
 
     assert!(client.get_scheduled_status(query_parameters).await.is_err());
 }
@@ -537,7 +537,7 @@ async fn test_update_scheduled_status_valid() {
 
     let client = SmsClient::with_configuration(get_test_configuration(&server.base_url()));
 
-    let query_parameters = UpdateScheduledStatusQueryParameters::new("BULK-ID-123-xyz".to_string());
+    let query_parameters = UpdateScheduledStatusQueryParameters::new("BULK-ID-123-xyz");
     let request_body = UpdateScheduledStatusRequestBody::new(PAUSED);
 
     let response = client
@@ -554,7 +554,7 @@ async fn test_update_scheduled_status_valid() {
 async fn test_update_scheduled_status_empty_bulk_id() {
     let client = SmsClient::with_configuration(get_test_configuration("https://some.url"));
 
-    let query_parameters = UpdateScheduledStatusQueryParameters::new("".to_string());
+    let query_parameters = UpdateScheduledStatusQueryParameters::new("");
     let request_body = UpdateScheduledStatusRequestBody::new(PAUSED);
 
     assert!(client
@@ -774,7 +774,7 @@ async fn test_create_tfa_application_valid() {
 
     let client = SmsClient::with_configuration(get_test_configuration(&server.base_url()));
 
-    let request_body = CreateTfaApplicationRequestBody::new("Application name".to_string());
+    let request_body = CreateTfaApplicationRequestBody::new("Application name");
 
     let response = client.create_tfa_application(request_body).await.unwrap();
 
@@ -786,7 +786,7 @@ async fn test_create_tfa_application_valid() {
 async fn test_create_tfa_application_no_name() {
     let client = SmsClient::with_configuration(get_test_configuration("https://some.url"));
 
-    let request_body = CreateTfaApplicationRequestBody::new("".to_string());
+    let request_body = CreateTfaApplicationRequestBody::new("");
 
     assert!(client.create_tfa_application(request_body).await.is_err());
 }
@@ -853,7 +853,7 @@ async fn test_update_tfa_application_valid() {
 
     let client = SmsClient::with_configuration(get_test_configuration(&server.base_url()));
 
-    let request_body = UpdateTfaApplicationRequestBody::new("Application name 2".to_string());
+    let request_body = UpdateTfaApplicationRequestBody::new("Application name 2");
 
     let response = client
         .update_tfa_application("1234567", request_body)
@@ -926,11 +926,8 @@ async fn test_create_tfa_message_template_valid() {
 
     let client = SmsClient::with_configuration(get_test_configuration(&server.base_url()));
 
-    let request_body = CreateTfaMessageTemplateRequestBody::new(
-        "Your pin is {{pin}}".to_string(),
-        PinType::Alphanumeric,
-        4,
-    );
+    let request_body =
+        CreateTfaMessageTemplateRequestBody::new("Your pin is {{pin}}", PinType::Alphanumeric, 4);
     let application_id = "HJ675435E3A6EA43432G5F37A635KJ8B";
 
     let response = client
@@ -946,8 +943,7 @@ async fn test_create_tfa_message_template_valid() {
 async fn test_create_tfa_message_template_empty_message_text() {
     let client = SmsClient::with_configuration(get_test_configuration("https://some.url"));
 
-    let request_body =
-        CreateTfaMessageTemplateRequestBody::new("".to_string(), PinType::Alphanumeric, 4);
+    let request_body = CreateTfaMessageTemplateRequestBody::new("", PinType::Alphanumeric, 4);
 
     assert!(client
         .create_tfa_message_template("some-app-id", request_body)
@@ -1023,11 +1019,8 @@ async fn test_update_tfa_message_template_valid() {
 
     let client = SmsClient::with_configuration(get_test_configuration(&server.base_url()));
 
-    let request_body = UpdateTfaMessageTemplateRequestBody::new(
-        "Your pin is {{pin}}".to_string(),
-        PinType::Alphanumeric,
-        6,
-    );
+    let request_body =
+        UpdateTfaMessageTemplateRequestBody::new("Your pin is {{pin}}", PinType::Alphanumeric, 6);
 
     let response = client
         .update_tfa_message_template(
@@ -1065,9 +1058,9 @@ async fn test_send_pin_over_sms_valid() {
 
     let query_parameters = SendPinOverSmsQueryParameters::default();
     let request_body = SendPinOverSmsRequestBody::new(
-        "HJ675435E3A6EA43432G5F37A635KJ8B".to_string(),
-        "16A8B5FE2BCD6CA716A2D780CB3F3390".to_string(),
-        "5555555555".to_string(),
+        "HJ675435E3A6EA43432G5F37A635KJ8B",
+        "16A8B5FE2BCD6CA716A2D780CB3F3390",
+        "5555555555",
     );
 
     let response = client
@@ -1087,11 +1080,8 @@ async fn test_send_pin_over_sms_empty_app_id() {
     let client = SmsClient::with_configuration(get_test_configuration("https://some.url"));
 
     let query_parameters = SendPinOverSmsQueryParameters::default();
-    let request_body = SendPinOverSmsRequestBody::new(
-        "".to_string(),
-        "16A8B5FE2BCD6CA716A2D780CB3F3390".to_string(),
-        "5555555555".to_string(),
-    );
+    let request_body =
+        SendPinOverSmsRequestBody::new("", "16A8B5FE2BCD6CA716A2D780CB3F3390", "5555555555");
 
     assert!(client
         .send_pin_over_sms(query_parameters, request_body)
@@ -1158,9 +1148,9 @@ async fn test_send_pin_over_voice_valid() {
     let client = SmsClient::with_configuration(get_test_configuration(&server.base_url()));
 
     let request_body = SendPinOverVoiceRequestBody::new(
-        "HJ675435E3A6EA43432G5F37A635KJ8B".to_string(),
-        "16A8B5FE2BCD6CA716A2D780CB3F3390".to_string(),
-        "5555555555".to_string(),
+        "HJ675435E3A6EA43432G5F37A635KJ8B",
+        "16A8B5FE2BCD6CA716A2D780CB3F3390",
+        "5555555555",
     );
 
     let response = client.send_pin_over_voice(request_body).await.unwrap();
@@ -1176,11 +1166,8 @@ async fn test_send_pin_over_voice_valid() {
 async fn test_send_pin_over_voice_empty_app_id() {
     let client = SmsClient::with_configuration(get_test_configuration("https://some.url"));
 
-    let request_body = SendPinOverVoiceRequestBody::new(
-        "".to_string(),
-        "16A8B5FE2BCD6CA716A2D780CB3F3390".to_string(),
-        "5555555555".to_string(),
-    );
+    let request_body =
+        SendPinOverVoiceRequestBody::new("", "16A8B5FE2BCD6CA716A2D780CB3F3390", "5555555555");
 
     assert!(client.send_pin_over_voice(request_body).await.is_err());
 }
@@ -1246,7 +1233,7 @@ async fn test_verify_phone_number_valid() {
 
     let client = SmsClient::with_configuration(get_test_configuration(&server.base_url()));
 
-    let request_body = VerifyPhoneNumberRequestBody::new("123456".to_string());
+    let request_body = VerifyPhoneNumberRequestBody::new("123456");
 
     let response = client
         .verify_phone_number("9C817C6F8AF3D48F9FE553282AFA2B67", request_body)
@@ -1264,7 +1251,7 @@ async fn test_verify_phone_number_valid() {
 async fn test_verify_phone_number_no_pin() {
     let client = SmsClient::with_configuration(get_test_configuration("https://some.url"));
 
-    let request_body = VerifyPhoneNumberRequestBody::new("".to_string());
+    let request_body = VerifyPhoneNumberRequestBody::new("");
 
     assert!(client
         .verify_phone_number("some-pin-id", request_body)
@@ -1300,7 +1287,7 @@ async fn test_get_tfa_verification_status_valid() {
 
     let client = SmsClient::with_configuration(get_test_configuration(&server.base_url()));
 
-    let query_parameters = GetTfaVerificationStatusQueryParameters::new("41793026727".to_string());
+    let query_parameters = GetTfaVerificationStatusQueryParameters::new("41793026727");
 
     let response = client
         .get_tfa_verification_status("16A8B5FE2BCD6CA716A2D780CB3F3390", query_parameters)
@@ -1315,7 +1302,7 @@ async fn test_get_tfa_verification_status_valid() {
 async fn test_get_tfa_verification_status_empty_msisdn() {
     let client = SmsClient::with_configuration(get_test_configuration("https://some.url"));
 
-    let query_parameters = GetTfaVerificationStatusQueryParameters::new("".to_string());
+    let query_parameters = GetTfaVerificationStatusQueryParameters::new("");
 
     assert!(client
         .get_tfa_verification_status("some-app-id", query_parameters)

--- a/src/api/tests/whatsapp.rs
+++ b/src/api/tests/whatsapp.rs
@@ -4,11 +4,7 @@ use crate::api::SdkError::ApiRequestError;
 use crate::model::whatsapp::*;
 
 fn get_dummy_send_text_request_body() -> SendTextRequestBody {
-    SendTextRequestBody::new(
-        "44444444444".to_string(),
-        "55555555555".to_string(),
-        TextContent::new("some text".to_string()),
-    )
+    SendTextRequestBody::new("44444444444", "55555555555", TextContent::new("some text"))
 }
 
 #[tokio::test]
@@ -62,11 +58,8 @@ async fn send_text_valid() {
 
 #[tokio::test]
 async fn send_text_api_error() {
-    let request_body = SendTextRequestBody::new(
-        "44444444444".to_string(),
-        "55555555555".to_string(),
-        TextContent::new("some text".to_string()),
-    );
+    let request_body =
+        SendTextRequestBody::new("44444444444", "55555555555", TextContent::new("some text"));
 
     let expected_response = r#"
         {
@@ -107,7 +100,7 @@ async fn send_text_api_error() {
                     .service_exception
                     .message_id
                     .unwrap(),
-                "BAD_REQUEST".to_string()
+                "BAD_REQUEST"
             );
         }
         _ => {
@@ -155,7 +148,7 @@ async fn send_text_api_error_401() {
                     .service_exception
                     .message_id
                     .unwrap(),
-                "UNAUTHORIZED".to_string()
+                "UNAUTHORIZED"
             );
         }
         _ => {
@@ -203,7 +196,7 @@ async fn send_text_api_error_429() {
                     .service_exception
                     .message_id
                     .unwrap(),
-                "TOO_MANY_REQUESTS".to_string()
+                "TOO_MANY_REQUESTS"
             );
         }
         _ => {
@@ -802,7 +795,7 @@ async fn get_templates_valid() {
         }
     "#;
 
-    let sender = "441134960000".to_string();
+    let sender = "441134960000";
     let path = PATH_GET_TEMPLATES.replace("{sender}", &sender);
 
     let server = mock_json_endpoint(
@@ -892,7 +885,7 @@ async fn create_template_valid() {
         }
     "#;
 
-    let sender = "441134960000".to_string();
+    let sender = "441134960000";
     let path = PATH_CREATE_TEMPLATE.replace("{sender}", &sender);
 
     let server = mock_json_endpoint(
@@ -916,11 +909,11 @@ async fn create_template_valid() {
 
 #[tokio::test]
 async fn delete_template_valid() {
-    let template_name = "media_template_with_buttons".to_string();
-    let sender = "441134960000".to_string();
+    let template_name = "media_template_with_buttons";
+    let sender = "441134960000";
     let path = PATH_DELETE_TEMPLATE
-        .replace("{sender}", &sender)
-        .replace("{templateName}", &template_name);
+        .replace("{sender}", sender)
+        .replace("{templateName}", template_name);
 
     let server = mock_json_endpoint(
         httpmock::Method::DELETE,

--- a/src/api/whatsapp.rs
+++ b/src/api/whatsapp.rs
@@ -91,9 +91,9 @@ impl WhatsappClient {
     /// let wa_client = WhatsappClient::with_configuration(Configuration::from_env_api_key()?);
     ///
     /// let request_body = SendTextRequestBody::new(
-    ///     "44444444444".to_string(),
-    ///     "55555555555".to_string(),
-    ///     TextContent::new("Hello, Rustacean!".to_string())
+    ///     "44444444444",
+    ///     "55555555555",
+    ///     TextContent::new("Hello, Rustacean!")
     /// );
     ///
     /// let response = wa_client.send_text(request_body).await.unwrap();
@@ -139,9 +139,9 @@ impl WhatsappClient {
     /// let wa_client = WhatsappClient::with_configuration(Configuration::from_env_api_key()?);
     ///
     /// let request_body = SendDocumentRequestBody::new(
-    ///     "44444444444".to_string(),
-    ///     "55555555555".to_string(),
-    ///     DocumentContent::new("https://url.to/document.pdf".to_string())
+    ///     "44444444444",
+    ///     "55555555555",
+    ///     DocumentContent::new("https://url.to/document.pdf")
     /// );
     ///
     /// let response = wa_client.send_document(request_body).await.unwrap();
@@ -192,9 +192,9 @@ impl WhatsappClient {
     /// let wa_client = WhatsappClient::with_configuration(Configuration::from_env_api_key()?);
     ///
     /// let request_body = SendImageRequestBody::new(
-    ///     "44444444444".to_string(),
-    ///     "55555555555".to_string(),
-    ///     ImageContent::new("https://url.to/image.jpg".to_string())
+    ///     "44444444444",
+    ///     "55555555555",
+    ///     ImageContent::new("https://url.to/image.jpg")
     /// );
     ///
     /// let response = wa_client.send_image(request_body).await.unwrap();
@@ -240,9 +240,9 @@ impl WhatsappClient {
     /// let wa_client = WhatsappClient::with_configuration(Configuration::from_env_api_key()?);
     ///
     /// let request_body = SendAudioRequestBody::new(
-    ///     "44444444444".to_string(),
-    ///     "55555555555".to_string(),
-    ///     AudioContent::new("https://url.to/audio.mp3".to_string())
+    ///     "44444444444",
+    ///     "55555555555",
+    ///     AudioContent::new("https://url.to/audio.mp3")
     /// );
     ///
     /// let response = wa_client.send_audio(request_body).await.unwrap();
@@ -288,9 +288,9 @@ impl WhatsappClient {
     /// let wa_client = WhatsappClient::with_configuration(Configuration::from_env_api_key()?);
     ///
     /// let request_body = SendVideoRequestBody::new(
-    ///     "44444444444".to_string(),
-    ///     "55555555555".to_string(),
-    ///     VideoContent::new("https://url.to/video.mp4".to_string())
+    ///     "44444444444",
+    ///     "55555555555",
+    ///     VideoContent::new("https://url.to/video.mp4")
     /// );
     ///
     /// let response = wa_client.send_video(request_body).await.unwrap();
@@ -336,9 +336,9 @@ impl WhatsappClient {
     /// let wa_client = WhatsappClient::with_configuration(Configuration::from_env_api_key()?);
     ///
     /// let request_body = SendStickerRequestBody::new(
-    ///     "44444444444".to_string(),
-    ///     "55555555555".to_string(),
-    ///     StickerContent::new("https://url.to/sticker.webp".to_string())
+    ///     "44444444444",
+    ///     "55555555555",
+    ///     StickerContent::new("https://url.to/sticker.webp")
     /// );
     ///
     /// let response = wa_client.send_sticker(request_body).await.unwrap();
@@ -389,8 +389,8 @@ impl WhatsappClient {
     /// let wa_client = WhatsappClient::with_configuration(Configuration::from_env_api_key()?);
     ///
     /// let request_body = SendLocationRequestBody::new(
-    ///     "44444444444".to_string(),
-    ///     "55555555555".to_string(),
+    ///     "44444444444",
+    ///     "55555555555",
     ///     LocationContent::new(0.0, 0.0)
     /// );
     ///
@@ -441,10 +441,10 @@ impl WhatsappClient {
     /// # async fn main() -> Result<(), Box<dyn std::error::Error>> {
     /// let wa_client = WhatsappClient::with_configuration(Configuration::from_env_api_key()?);
     ///
-    /// let contact = Contact::new(ContactName::new("John".to_string(), "Doe".to_string()));
+    /// let contact = Contact::new(ContactName::new("John", "Doe"));
     /// let request_body = SendContactRequestBody::new(
-    ///     "44444444444".to_string(),
-    ///     "55555555555".to_string(),
+    ///     "44444444444",
+    ///     "55555555555",
     ///     ContactContent::new(vec![contact])
     /// );
     ///
@@ -501,12 +501,12 @@ impl WhatsappClient {
     /// # async fn main() -> Result<(), Box<dyn std::error::Error>> {
     /// let wa_client = WhatsappClient::with_configuration(Configuration::from_env_api_key()?);
     ///
-    /// let button = InteractiveButton::new_reply_button("1".to_string(), "button1".to_string());
-    /// let body = InteractiveBody::new("Hello World".to_string());
+    /// let button = InteractiveButton::new_reply_button("1", "button1");
+    /// let body = InteractiveBody::new("Hello World");
     /// let action = InteractiveButtonsAction::new(vec![button]);
     /// let request_body = SendInteractiveButtonsRequestBody::new(
-    ///     "44444444444".to_string(),
-    ///     "55555555555".to_string(),
+    ///     "44444444444",
+    ///     "55555555555",
     ///     InteractiveButtonsContent::new(body, action)
     /// );
     ///
@@ -563,13 +563,13 @@ impl WhatsappClient {
     /// # async fn main() -> Result<(), Box<dyn std::error::Error>> {
     /// let wa_client = WhatsappClient::with_configuration(Configuration::from_env_api_key()?);
     ///
-    /// let body = InteractiveBody::new("Hello World".to_string());
-    /// let row = InteractiveRow::new("1".to_string(), "row1".to_string());
+    /// let body = InteractiveBody::new("Hello World");
+    /// let row = InteractiveRow::new("1", "row1");
     /// let section = InteractiveListSection::new(vec![row]);
-    /// let action = InteractiveListAction::new("list_title".to_string(), vec![section]);
+    /// let action = InteractiveListAction::new("list_title", vec![section]);
     /// let request_body = SendInteractiveListRequestBody::new(
-    ///     "44444444444".to_string(),
-    ///     "55555555555".to_string(),
+    ///     "44444444444",
+    ///     "55555555555",
     ///     InteractiveListContent::new(body, action)
     /// );
     ///
@@ -621,10 +621,10 @@ impl WhatsappClient {
     /// # async fn main() -> Result<(), Box<dyn std::error::Error>> {
     /// let wa_client = WhatsappClient::with_configuration(Configuration::from_env_api_key()?);
     ///
-    /// let action = InteractiveProductAction::new("1".to_string(), "2".to_string());
+    /// let action = InteractiveProductAction::new("1", "2");
     /// let request_body = SendInteractiveProductRequestBody::new(
-    ///     "44444444444".to_string(),
-    ///     "55555555555".to_string(),
+    ///     "44444444444",
+    ///     "55555555555",
     ///      InteractiveProductContent::new(action)
     /// );
     ///
@@ -681,13 +681,13 @@ impl WhatsappClient {
     /// # async fn main() -> Result<(), Box<dyn std::error::Error>> {
     /// let wa_client = WhatsappClient::with_configuration(Configuration::from_env_api_key()?);
     ///
-    /// let header = InteractiveMultiproductHeader::new_text_header("header1".to_string());
-    /// let body = InteractiveBody::new("Hello World".to_string());
+    /// let header = InteractiveMultiproductHeader::new_text_header("header1");
+    /// let body = InteractiveBody::new("Hello World");
     /// let section = InteractiveMultiproductSection::new(vec!["1".to_string(), "2".to_string()]);
-    /// let action = InteractiveMultiproductAction::new("1".to_string(), vec![section]);
+    /// let action = InteractiveMultiproductAction::new("1", vec![section]);
     /// let request_body = SendInteractiveMultiproductRequestBody::new(
-    ///     "44444444444".to_string(),
-    ///     "55555555555".to_string(),
+    ///     "44444444444",
+    ///     "55555555555",
     ///     InteractiveMultiproductContent::new(header, body, action)
     /// );
     ///
@@ -743,16 +743,16 @@ impl WhatsappClient {
     /// # async fn main() -> Result<(), Box<dyn std::error::Error>> {
     /// let wa_client = WhatsappClient::with_configuration(Configuration::from_env_api_key()?);
     ///
-    /// let structure = TemplateStructure::new(TemplateBody::new("Hello World".to_string()));
+    /// let structure = TemplateStructure::new(TemplateBody::new("Hello World"));
     /// let request_body = CreateTemplateRequestBody::new(
-    ///     "template_name".to_string(),
+    ///     "template_name",
     ///     TemplateLanguage::EnUs,
     ///     TemplateCategory::Marketing,
     ///     structure,
     /// );
     ///
     /// let response = wa_client.create_template(
-    ///     "1234567891011".to_string(),
+    ///     "1234567891011",
     ///     request_body)
     /// .await.unwrap();
     ///
@@ -762,10 +762,10 @@ impl WhatsappClient {
     /// ```
     pub async fn create_template(
         &self,
-        sender: String,
+        sender: &str,
         request_body: CreateTemplateRequestBody,
     ) -> Result<SdkResponse<CreateTemplateResponseBody>, SdkError> {
-        let path = PATH_CREATE_TEMPLATE.replace("{sender}", &sender);
+        let path = PATH_CREATE_TEMPLATE.replace("{sender}", sender);
 
         let response = self
             .send_request(request_body, HashMap::new(), Method::POST, path.as_str())
@@ -795,7 +795,7 @@ impl WhatsappClient {
     /// # async fn main() -> Result<(), Box<dyn std::error::Error>> {
     /// let wa_client = WhatsappClient::with_configuration(Configuration::from_env_api_key()?);
     ///
-    /// let response = wa_client.get_templates("12345789101112".to_string()).await.unwrap();
+    /// let response = wa_client.get_templates("12345789101112").await.unwrap();
     ///
     /// assert_eq!(response.status, StatusCode::OK);
     /// # Ok(())
@@ -803,9 +803,9 @@ impl WhatsappClient {
     /// ```
     pub async fn get_templates(
         &self,
-        sender: String,
+        sender: &str,
     ) -> Result<SdkResponse<GetTemplatesResponseBody>, SdkError> {
-        let path = PATH_GET_TEMPLATES.replace("{sender}", &sender);
+        let path = PATH_GET_TEMPLATES.replace("{sender}", sender);
 
         let response = send_no_body_request(
             &self.client,
@@ -850,8 +850,8 @@ impl WhatsappClient {
     /// let wa_client = WhatsappClient::with_configuration(Configuration::from_env_api_key()?);
     ///
     /// let status = wa_client.delete_template(
-    ///     "1234567891011".to_string(),
-    ///     "template_name".to_string()
+    ///     "1234567891011",
+    ///     "template_name"
     /// )
     /// .await.unwrap();
     ///
@@ -861,12 +861,12 @@ impl WhatsappClient {
     /// ```
     pub async fn delete_template(
         &self,
-        sender: String,
-        template_name: String,
+        sender: &str,
+        template_name: &str,
     ) -> Result<reqwest::StatusCode, SdkError> {
         let path = PATH_DELETE_TEMPLATE
-            .replace("{sender}", &sender)
-            .replace("{templateName}", &template_name);
+            .replace("{sender}", sender)
+            .replace("{templateName}", template_name);
 
         let response = send_no_body_request(
             &self.client,
@@ -912,10 +912,10 @@ impl WhatsappClient {
     ///
     /// let body = TemplateBodyContent::new(vec!["placeholder1".to_string()]);
     /// let data = TemplateData::new(body);
-    /// let content = TemplateContent::new("template_name".to_string(), data, TemplateLanguage::EnUs.to_string());
+    /// let content = TemplateContent::new("template_name", data, &TemplateLanguage::EnUs.to_string());
     /// let message = FailoverMessage::new(
-    ///     "1234567891011".to_string(),
-    ///     "1234567891012".to_string(),
+    ///     "1234567891011",
+    ///     "1234567891012",
     ///     content,
     /// );
     /// let request_body = SendTemplateRequestBody::new(vec![message]);

--- a/src/configuration/mod.rs
+++ b/src/configuration/mod.rs
@@ -11,18 +11,6 @@ pub struct Configuration {
 }
 
 impl Configuration {
-    /// Reads API key details and IB_BASE_URL environment variables after loading from .env file,
-    /// to build and return a `Configuration` instance.
-    pub fn from_dotenv_api_key() -> Result<Configuration, dotenv::Error> {
-        dotenv::dotenv().ok();
-        Ok(Configuration {
-            base_url: dotenv::var("IB_BASE_URL")?,
-            api_key: Some(ApiKey::from_dotenv()?),
-            basic_auth: None,
-            bearer_access_token: None,
-        })
-    }
-
     /// Reads API key details and IB_BASE_URL environment variable to build and return a
     /// `Configuration` instance.
     pub fn from_env_api_key() -> Result<Configuration, VarError> {
@@ -93,15 +81,6 @@ impl ApiKey {
         Ok(ApiKey {
             key: env::var("IB_API_KEY")?,
             prefix: Some(env::var("IB_API_KEY_PREFIX").unwrap_or_else(|_| "App".to_string())),
-        })
-    }
-
-    /// Reads `IB_API_KEY`, and optionally `IB_API_KEY_PREFIX`, variables from environment.
-    pub fn from_dotenv() -> Result<ApiKey, dotenv::Error> {
-        dotenv::dotenv().ok();
-        Ok(ApiKey {
-            key: dotenv::var("IB_API_KEY")?,
-            prefix: Some(dotenv::var("IB_API_KEY_PREFIX").unwrap_or_else(|_| "App".to_string())),
         })
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,31 +1,35 @@
 //! # Infobip SDK
 //! Client SDK to use the Infobip API with pure Rust.
 //!
-//! This crate enables you to use multiple Infobip communication channels, like SMS, MMS,
+//! This crate enables you to use multiple Infobip communication channels, like SMS, 2FA,
 //! WhatsApp, Email, etc. It abstracts the needed HTTP calls, models and validates payloads and
 //! models errors. The module structure is divided by communication channel.
 //!
 //! ## Supported Channels
+//! Currently, we support the following channels:
 //! - [SMS + 2FA](https://www.infobip.com/docs/api/channels/sms)
 //! - [WhatsApp](https://www.infobip.com/docs/api/channels/whatsapp)
 //! - [Email](https://www.infobip.com/docs/api/channels/email)
 //!
-//! More Channels to be added in the near future!
+//! More channels to be added in the near future!
 //!
 //! ## Authentication
 //! To use the library, you'll need to set up an [Infobip account](https://www.infobip.com/signup).
 //! Then you can use your API Key and custom base URL to call the endpoints. You can use the
 //! `Configuration::from_env_api_key()` method to load the configuration from the environment. To
-//! do that, set the `IB_API_KEY` and `IB_BASE_URL` variables. Alternatively, you can use the
-//! `Configuration::from_dotenv_api_key()` method to load the configuration from a `.env` file.
+//! do that, set the `IB_API_KEY` and `IB_BASE_URL` variables.
 //!
 //! ## Installation
-//! To use the library, add the dependency to your projects `Cargo.toml`
+//! To install the library, run the following command under your project's root directory:
+//! ```bash
+//! cargo add infobip_sdk
+//! ```
+//! Alternatively, you can add the dependency to your project's `Cargo.toml`
 //! ```toml
 //! [dependencies]
 //! infobip_sdk = "<version>"
 //! ```
-//! Replace <version> is the latest (or desired) release of the library. For example `0.2.0`.
+//! Replace `<version>` with the latest (or desired) release of the library. For example `0.5.0`.
 //!
 //! ## Usage
 //! To use the library, import the client and channel-specific models. Then create a client and
@@ -132,7 +136,7 @@
 //! You can speed up compile time by turning only the needed channels as library features.
 //! For example, to only build SMS, add the dependency like this:
 //! ```toml
-//! infobip_sdk = { version = "0.3", features = ["sms"] }
+//! infobip_sdk = { version = "0.5", features = ["sms"] }
 //! ```
 //! You can see the complete list of features in the Cargo.toml of the project. Feature names
 //! follow channel names.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,7 +6,7 @@
 //! models errors. The module structure is divided by communication channel.
 //!
 //! ## Supported Channels
-//! - [SMS](https://www.infobip.com/docs/api/channels/sms)
+//! - [SMS + 2FA](https://www.infobip.com/docs/api/channels/sms)
 //! - [WhatsApp](https://www.infobip.com/docs/api/channels/whatsapp)
 //! - [Email](https://www.infobip.com/docs/api/channels/email)
 //!

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -45,7 +45,7 @@
 //!
 //!     // Create a message.
 //!     let mut message = Message::new(
-//!         vec![Destination::new("123456789012".to_string())]
+//!         vec![Destination::new("123456789012")]
 //!     );
 //!     message.text = Some("Your message text".to_string());
 //!
@@ -76,7 +76,7 @@
 //! ```rust
 //! # use infobip_sdk::model::sms::{Destination, Message};
 //! let mut message = Message::new(
-//!    vec![Destination::new("123456789012".to_string())]
+//!    vec![Destination::new("123456789012")]
 //! );
 //! message.text = Some("Your message text".to_string());
 //! ```

--- a/src/model/email.rs
+++ b/src/model/email.rs
@@ -259,7 +259,9 @@ pub struct GetBulksQueryParameters {
 
 impl GetBulksQueryParameters {
     pub fn new(bulk_id: &str) -> Self {
-        GetBulksQueryParameters { bulk_id: bulk_id.into() }
+        GetBulksQueryParameters {
+            bulk_id: bulk_id.into(),
+        }
     }
 }
 
@@ -294,7 +296,9 @@ pub struct RescheduleRequestBody {
 
 impl RescheduleRequestBody {
     pub fn new(send_at: &str) -> Self {
-        RescheduleRequestBody { send_at: send_at.into() }
+        RescheduleRequestBody {
+            send_at: send_at.into(),
+        }
     }
 }
 

--- a/src/model/email.rs
+++ b/src/model/email.rs
@@ -141,10 +141,10 @@ pub struct SendRequestBody {
 }
 
 impl SendRequestBody {
-    pub fn new(to: String) -> Self {
+    pub fn new(to: &str) -> Self {
         SendRequestBody {
             from: None,
-            to,
+            to: to.into(),
             cc: None,
             bcc: None,
             subject: None,
@@ -258,8 +258,8 @@ pub struct GetBulksQueryParameters {
 }
 
 impl GetBulksQueryParameters {
-    pub fn new(bulk_id: String) -> Self {
-        GetBulksQueryParameters { bulk_id }
+    pub fn new(bulk_id: &str) -> Self {
+        GetBulksQueryParameters { bulk_id: bulk_id.into() }
     }
 }
 
@@ -293,8 +293,8 @@ pub struct RescheduleRequestBody {
 }
 
 impl RescheduleRequestBody {
-    pub fn new(send_at: String) -> Self {
-        RescheduleRequestBody { send_at }
+    pub fn new(send_at: &str) -> Self {
+        RescheduleRequestBody { send_at: send_at.into() }
     }
 }
 
@@ -558,8 +558,8 @@ pub struct ValidateAddressRequestBody {
 }
 
 impl ValidateAddressRequestBody {
-    pub fn new(to: String) -> Self {
-        ValidateAddressRequestBody { to }
+    pub fn new(to: &str) -> Self {
+        ValidateAddressRequestBody { to: to.into() }
     }
 }
 
@@ -746,9 +746,9 @@ pub struct AddDomainRequestBody {
 }
 
 impl AddDomainRequestBody {
-    pub fn new(domain_name: String) -> Self {
+    pub fn new(domain_name: &str) -> Self {
         AddDomainRequestBody {
-            domain_name,
+            domain_name: domain_name.into(),
             dkim_key_length: None,
         }
     }

--- a/src/model/sms.rs
+++ b/src/model/sms.rs
@@ -1,8 +1,8 @@
 //! Models for calling SMS endpoints.
 
-use std::collections::HashMap;
 use regex::Regex;
 use serde_derive::{Deserialize, Serialize};
+use std::collections::HashMap;
 use validator::Validate;
 
 lazy_static! {
@@ -444,6 +444,7 @@ impl Destination {
 pub struct IndiaDlt {
     /// Id of your registered DTL content template that matches this message's text.
     #[serde(skip_serializing_if = "Option::is_none")]
+    #[validate(length(max = 30))]
     pub content_template_id: Option<String>,
 
     /// Your assigned DTL principal entity id.
@@ -1298,6 +1299,7 @@ pub struct TfaApplication {
     pub enabled: Option<bool>,
 
     /// 2FA application name.
+    #[validate(length(min = 1))]
     pub name: String,
 }
 
@@ -1408,11 +1410,12 @@ pub struct TfaMessageTemplate {
     pub message_id: Option<String>,
 
     /// Text of a message that will be sent. Message text must contain `pinPlaceholder`.
+    #[validate(length(min = 1))]
     pub message_text: String,
 
     /// PIN code length.
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub pin_length: Option<i32>,
+    #[validate(range(min = 1))]
+    pub pin_length: i32,
 
     /// The PIN code placeholder that will be replaced with a generated PIN code.
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -1437,6 +1440,24 @@ pub struct TfaMessageTemplate {
     /// In case PIN message is sent by Voice, the speed of speech can be set for the message. Supported range is from `0.5` to `2`.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub speech_rate: Option<f64>,
+}
+
+impl TfaMessageTemplate {
+    pub fn new(message_text: String, pin_type: PinType, pin_length: i32) -> TfaMessageTemplate {
+        TfaMessageTemplate {
+            application_id: None,
+            language: None,
+            message_id: None,
+            message_text,
+            pin_length,
+            pin_placeholder: None,
+            pin_type,
+            regional: None,
+            repeat_dtmf: None,
+            sender_id: None,
+            speech_rate: None,
+        }
+    }
 }
 
 pub type GetTfaMessageTemplatesResponseBody = Vec<TfaMessageTemplate>;
@@ -1473,6 +1494,7 @@ impl Default for SendPinOverSmsQueryParameters {
 #[serde(rename_all = "camelCase")]
 pub struct SendPinOverSmsRequestBody {
     /// The ID of the application that represents your service, e.g. 2FA for login, 2FA for changing the password, etc.
+    #[validate(length(min = 1))]
     pub application_id: String,
 
     /// Use this parameter if you wish to override the sender ID from the [created](#channels/sms/create-2fa-message-template) message template parameter `senderId`.
@@ -1480,6 +1502,7 @@ pub struct SendPinOverSmsRequestBody {
     pub from: Option<String>,
 
     /// The ID of the message template (message body with the PIN placeholder) that is sent to the recipient.
+    #[validate(length(min = 1))]
     pub message_id: String,
 
     /// Key value pairs that will be replaced during message sending. Placeholder keys should NOT contain curly brackets and should NOT contain a `pin` placeholder. Valid example: `\"placeholders\":{\"firstName\":\"John\"}`
@@ -1487,6 +1510,7 @@ pub struct SendPinOverSmsRequestBody {
     pub placeholders: Option<HashMap<String, String>>,
 
     /// Phone number to which the 2FA message will be sent. Example: 41793026727.
+    #[validate(length(min = 1))]
     pub to: String,
 }
 
@@ -1536,6 +1560,18 @@ pub struct ResendPinRequestBody {
     pub placeholders: Option<HashMap<String, String>>,
 }
 
+impl ResendPinRequestBody {
+    pub fn new() -> Self {
+        Self { placeholders: None }
+    }
+}
+
+impl Default for ResendPinRequestBody {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 pub type ResendPinOverSmsRequestBody = ResendPinRequestBody;
 
 pub type ResendPinOverSmsResponseBody = SendPinResponseBody;
@@ -1544,9 +1580,14 @@ pub type SendPinOverVoiceRequestBody = SendPinOverSmsRequestBody;
 
 pub type SendPinOverVoiceResponseBody = SendPinResponseBody;
 
+pub type ResendPinOverVoiceRequestBody = ResendPinRequestBody;
+
+pub type ResendPinOverVoiceResponseBody = SendPinResponseBody;
+
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize, Validate)]
 pub struct VerifyPhoneNumberRequestBody {
     /// ID of the pin code that has to be verified.
+    #[validate(length(min = 1))]
     pub pin: String,
 }
 

--- a/src/model/sms.rs
+++ b/src/model/sms.rs
@@ -1268,21 +1268,21 @@ pub struct TfaApplicationConfiguration {
     #[serde(rename = "pinTimeToLive", skip_serializing_if = "Option::is_none")]
     pub pin_time_to_live: Option<String>,
 
-    /// Overall number of requests over a specififed time period for generating a PIN and sending an SMS using a single application. Required format: `{attempts}/{timeLength}{timeUnit}`. `attempts` is mandatory and `timeLength` is optional with a default value of 1. `timeUnit` is one of: `ms`, `s`, `m`, `h` or `d` representing milliseconds, seconds, minutes, hours, and days respectively. Must not exceed one year, although much lower value is recommended.
+    /// Overall number of requests over a specified time period for generating a PIN and sending an SMS using a single application. Required format: `{attempts}/{timeLength}{timeUnit}`. `attempts` is mandatory and `timeLength` is optional with a default value of 1. `timeUnit` is one of: `ms`, `s`, `m`, `h` or `d` representing milliseconds, seconds, minutes, hours, and days respectively. Must not exceed one year, although much lower value is recommended.
     #[serde(
         rename = "sendPinPerApplicationLimit",
         skip_serializing_if = "Option::is_none"
     )]
     pub send_pin_per_application_limit: Option<String>,
 
-    /// Number of requests over a specififed time period for generating a PIN and sending an SMS to one phone number (MSISDN). Required format: `{attempts}/{timeLength}{timeUnit}`. `attempts` is mandatory and `timeLength` is optional with a default value of 1. `timeUnit` is one of: `ms`, `s`, `m`, `h` or `d` representing milliseconds, seconds, minutes, hours, and days respectively. Must not exceed one year, although much lower value is recommended.
+    /// Number of requests over a specified time period for generating a PIN and sending an SMS to one phone number (MSISDN). Required format: `{attempts}/{timeLength}{timeUnit}`. `attempts` is mandatory and `timeLength` is optional with a default value of 1. `timeUnit` is one of: `ms`, `s`, `m`, `h` or `d` representing milliseconds, seconds, minutes, hours, and days respectively. Must not exceed one year, although much lower value is recommended.
     #[serde(
         rename = "sendPinPerPhoneNumberLimit",
         skip_serializing_if = "Option::is_none"
     )]
     pub send_pin_per_phone_number_limit: Option<String>,
 
-    /// The number of PIN verification requests over a specififed time period from one phone number (MSISDN). Required format: `{attempts}/{timeLength}{timeUnit}`. `attempts` is mandatory and `timeLength` is optional with a default value of 1. `timeUnit` is one of: `ms`, `s`, `m`, `h` or `d` representing milliseconds, seconds, minutes, hours, and days respectively. Must not exceed one day, although much lower value is recommended.
+    /// The number of PIN verification requests over a specified time period from one phone number (MSISDN). Required format: `{attempts}/{timeLength}{timeUnit}`. `attempts` is mandatory and `timeLength` is optional with a default value of 1. `timeUnit` is one of: `ms`, `s`, `m`, `h` or `d` representing milliseconds, seconds, minutes, hours, and days respectively. Must not exceed one day, although much lower value is recommended.
     #[serde(rename = "verifyPinLimit", skip_serializing_if = "Option::is_none")]
     pub verify_pin_limit: Option<String>,
 }

--- a/src/model/sms.rs
+++ b/src/model/sms.rs
@@ -33,10 +33,10 @@ pub struct PreviewRequestBody {
 }
 
 impl PreviewRequestBody {
-    pub fn new(text: String) -> PreviewRequestBody {
+    pub fn new(text: &str) -> PreviewRequestBody {
         PreviewRequestBody {
             language_code: None,
-            text,
+            text: text.into(),
             transliteration: None,
         }
     }
@@ -52,9 +52,9 @@ pub struct Language {
 }
 
 impl Language {
-    pub fn new(language_code: String) -> Language {
+    pub fn new(language_code: &str) -> Language {
         Language {
-            language_code: Some(language_code),
+            language_code: Some(language_code.into()),
         }
     }
 }
@@ -431,10 +431,10 @@ pub struct Destination {
 }
 
 impl Destination {
-    pub fn new(to: String) -> Destination {
+    pub fn new(to: &str) -> Destination {
         Destination {
             message_id: None,
-            to,
+            to: to.into(),
         }
     }
 }
@@ -453,10 +453,10 @@ pub struct IndiaDlt {
 }
 
 impl IndiaDlt {
-    pub fn new(principal_entity_id: String) -> IndiaDlt {
+    pub fn new(principal_entity_id: &str) -> IndiaDlt {
         IndiaDlt {
             content_template_id: None,
-            principal_entity_id,
+            principal_entity_id: principal_entity_id.into(),
         }
     }
 }
@@ -475,10 +475,10 @@ pub struct TurkeyIys {
 }
 
 impl TurkeyIys {
-    pub fn new(recipient_type: String) -> TurkeyIys {
+    pub fn new(recipient_type: &str) -> TurkeyIys {
         TurkeyIys {
             brand_code: None,
-            recipient_type,
+            recipient_type: recipient_type.into(),
         }
     }
 }
@@ -643,11 +643,11 @@ pub struct BinaryData {
 }
 
 impl BinaryData {
-    pub fn new(hex: String) -> BinaryData {
+    pub fn new(hex: &str) -> BinaryData {
         BinaryData {
             data_coding: None,
             esm_class: None,
-            hex,
+            hex: hex.into(),
         }
     }
 }
@@ -857,8 +857,10 @@ pub struct GetScheduledQueryParameters {
 }
 
 impl GetScheduledQueryParameters {
-    pub fn new(bulk_id: String) -> GetScheduledQueryParameters {
-        GetScheduledQueryParameters { bulk_id }
+    pub fn new(bulk_id: &str) -> GetScheduledQueryParameters {
+        GetScheduledQueryParameters {
+            bulk_id: bulk_id.into(),
+        }
     }
 }
 
@@ -1157,13 +1159,13 @@ pub struct SendOverQueryParametersQueryParameters {
 
 impl SendOverQueryParametersQueryParameters {
     pub fn new(
-        username: String,
-        password: String,
+        username: &str,
+        password: &str,
         to: Vec<String>,
     ) -> SendOverQueryParametersQueryParameters {
         SendOverQueryParametersQueryParameters {
-            username,
-            password,
+            username: username.into(),
+            password: password.into(),
             bulk_id: None,
             from: None,
             to,
@@ -1201,8 +1203,10 @@ pub struct RescheduleRequestBody {
 }
 
 impl RescheduleRequestBody {
-    pub fn new(send_at: String) -> RescheduleRequestBody {
-        RescheduleRequestBody { send_at }
+    pub fn new(send_at: &str) -> RescheduleRequestBody {
+        RescheduleRequestBody {
+            send_at: send_at.into(),
+        }
     }
 }
 
@@ -1310,12 +1314,12 @@ pub type CreateTfaApplicationRequestBody = TfaApplication;
 pub type CreateTfaApplicationResponseBody = TfaApplication;
 
 impl CreateTfaApplicationRequestBody {
-    pub fn new(name: String) -> CreateTfaApplicationRequestBody {
+    pub fn new(name: &str) -> CreateTfaApplicationRequestBody {
         CreateTfaApplicationRequestBody {
             application_id: None,
             configuration: None,
             enabled: None,
-            name,
+            name: name.into(),
         }
     }
 }
@@ -1443,12 +1447,12 @@ pub struct TfaMessageTemplate {
 }
 
 impl TfaMessageTemplate {
-    pub fn new(message_text: String, pin_type: PinType, pin_length: i32) -> TfaMessageTemplate {
+    pub fn new(message_text: &str, pin_type: PinType, pin_length: i32) -> TfaMessageTemplate {
         TfaMessageTemplate {
             application_id: None,
             language: None,
             message_id: None,
-            message_text,
+            message_text: message_text.into(),
             pin_length,
             pin_placeholder: None,
             pin_type,
@@ -1515,13 +1519,13 @@ pub struct SendPinOverSmsRequestBody {
 }
 
 impl SendPinOverSmsRequestBody {
-    pub fn new(application_id: String, message_id: String, to: String) -> Self {
+    pub fn new(application_id: &str, message_id: &str, to: &str) -> Self {
         Self {
-            application_id,
+            application_id: application_id.into(),
             from: None,
-            message_id,
+            message_id: message_id.into(),
             placeholders: None,
-            to,
+            to: to.into(),
         }
     }
 }
@@ -1592,8 +1596,8 @@ pub struct VerifyPhoneNumberRequestBody {
 }
 
 impl VerifyPhoneNumberRequestBody {
-    pub fn new(pin: String) -> Self {
-        Self { pin }
+    pub fn new(pin: &str) -> Self {
+        Self { pin: pin.into() }
     }
 }
 
@@ -1632,9 +1636,9 @@ pub struct GetTfaVerificationStatusQueryParameters {
 }
 
 impl GetTfaVerificationStatusQueryParameters {
-    pub fn new(msisdn: String) -> Self {
+    pub fn new(msisdn: &str) -> Self {
         Self {
-            msisdn,
+            msisdn: msisdn.into(),
             verified: None,
             sent: None,
         }

--- a/src/model/tests/email.rs
+++ b/src/model/tests/email.rs
@@ -3,7 +3,7 @@ use validator::Validate;
 use crate::model::email::*;
 
 pub fn get_dummy_send_email_request_body() -> SendRequestBody {
-    let mut request = SendRequestBody::new("some@company.com".to_string());
+    let mut request = SendRequestBody::new("some@company.com");
     request.from = Some("John Doe <john@company.com>".to_string());
     request.cc = Some("one@company.com,two@company.com".to_string());
     request.bcc = Some("three@company.com,four@some.com".to_string());
@@ -37,7 +37,7 @@ pub fn get_dummy_send_email_request_body() -> SendRequestBody {
 
 #[test]
 fn test_send_request_valid() {
-    let request_body = SendRequestBody::new("someone@company.com".to_string());
+    let request_body = SendRequestBody::new("someone@company.com");
 
     assert!(request_body.validate().is_ok());
 }
@@ -67,56 +67,56 @@ fn tets_send_request_body_long_callback_data() {
 
 #[test]
 fn test_get_bulks_query_parameters_valid() {
-    let query_params = GetBulksQueryParameters::new("some-bulk-id".to_string());
+    let query_params = GetBulksQueryParameters::new("some-bulk-id");
 
     assert!(query_params.validate().is_ok());
 }
 
 #[test]
 fn test_get_bulks_query_parameters_no_bulk_id() {
-    let query_params = GetBulksQueryParameters::new("".to_string());
+    let query_params = GetBulksQueryParameters::new("");
 
     assert!(query_params.validate().is_err());
 }
 
 #[test]
 fn test_reschedule_query_parameters_valid() {
-    let query_params = RescheduleQueryParameters::new("some-bulk-id".to_string());
+    let query_params = RescheduleQueryParameters::new("some-bulk-id");
 
     assert!(query_params.validate().is_ok());
 }
 
 #[test]
 fn test_reschedule_query_parameters_no_bulk_id() {
-    let query_params = RescheduleQueryParameters::new("".to_string());
+    let query_params = RescheduleQueryParameters::new("");
 
     assert!(query_params.validate().is_err());
 }
 
 #[test]
 fn test_reschedule_request_body_valid() {
-    let request_body = RescheduleRequestBody::new("2022-10-03T20:27:41Z".to_string());
+    let request_body = RescheduleRequestBody::new("2022-10-03T20:27:41Z");
 
     assert!(request_body.validate().is_ok());
 }
 
 #[test]
 fn test_reschedule_request_body_no_send_at() {
-    let request_body = RescheduleRequestBody::new("".to_string());
+    let request_body = RescheduleRequestBody::new("");
 
     assert!(request_body.validate().is_err());
 }
 
 #[test]
 fn test_validate_address_request_body_valid() {
-    let request_body = ValidateAddressRequestBody::new("hello@hi.com".to_string());
+    let request_body = ValidateAddressRequestBody::new("hello@hi.com");
 
     assert!(request_body.validate().is_ok());
 }
 
 #[test]
 fn test_validate_address_request_body_no_to() {
-    let request_body = ValidateAddressRequestBody::new("".to_string());
+    let request_body = ValidateAddressRequestBody::new("");
 
     assert!(request_body.validate().is_err());
 }
@@ -146,14 +146,14 @@ fn test_get_domains_query_parameters_invalid_page_size() {
 
 #[test]
 fn test_add_domain_request_body_valid() {
-    let request_body = AddDomainRequestBody::new("some-domain.com".to_string());
+    let request_body = AddDomainRequestBody::new("some-domain.com");
 
     assert!(request_body.validate().is_ok());
 }
 
 #[test]
 fn test_add_domain_request_body_no_domain() {
-    let request_body = AddDomainRequestBody::new("".to_string());
+    let request_body = AddDomainRequestBody::new("");
 
     assert!(request_body.validate().is_err());
 }

--- a/src/model/tests/sms.rs
+++ b/src/model/tests/sms.rs
@@ -6,7 +6,7 @@ const DUMMY_TEXT: &str = "Dummy text for tests. Some special chars: áéíø";
 
 #[test]
 fn sms_preview_request_body_valid() {
-    let mut request_body = PreviewRequestBody::new(DUMMY_TEXT.to_string());
+    let mut request_body = PreviewRequestBody::new(DUMMY_TEXT);
     request_body.language_code = Some("ES".to_string());
     request_body.transliteration = Some("GREEK".to_string());
 
@@ -15,7 +15,7 @@ fn sms_preview_request_body_valid() {
 
 #[test]
 fn sms_preview_request_body_invalid_language_code() {
-    let mut request_body = PreviewRequestBody::new(DUMMY_TEXT.to_string());
+    let mut request_body = PreviewRequestBody::new(DUMMY_TEXT);
     request_body.language_code = Some("BAD".to_string());
 
     assert!(request_body.validate().is_err())
@@ -23,7 +23,7 @@ fn sms_preview_request_body_invalid_language_code() {
 
 #[test]
 fn sms_preview_request_body_invalid_transliteration() {
-    let mut request_body = PreviewRequestBody::new(DUMMY_TEXT.to_string());
+    let mut request_body = PreviewRequestBody::new(DUMMY_TEXT);
     request_body.transliteration = Some("BAD".to_string());
 
     assert!(request_body.validate().is_err())
@@ -47,8 +47,8 @@ fn get_delivery_reports_query_parameters_big_limit() {
 
 #[test]
 fn send_request_body_valid() {
-    let mut message = Message::new(vec![Destination::new("123456789012".to_string())]);
-    message.text = Some(DUMMY_TEXT.to_string());
+    let mut message = Message::new(vec![Destination::new("123456789012")]);
+    message.text = Some(DUMMY_TEXT.into());
 
     let request_body = SendRequestBody::new(vec![message]);
 
@@ -72,7 +72,7 @@ fn send_request_body_no_destination() {
 
 #[test]
 fn send_request_body_no_destination_to() {
-    let message = Message::new(vec![Destination::new("".to_string())]);
+    let message = Message::new(vec![Destination::new("")]);
     let request_body = SendRequestBody::new(vec![message]);
 
     assert!(request_body.validate().is_err());
@@ -81,8 +81,8 @@ fn send_request_body_no_destination_to() {
 #[test]
 fn send_request_body_no_principal_entity_id() {
     let mut regional = RegionalOptions::new();
-    regional.india_dlt = Some(IndiaDlt::new("".to_string()));
-    let mut message = Message::new(vec![Destination::new("123456789012".to_string())]);
+    regional.india_dlt = Some(IndiaDlt::new(""));
+    let mut message = Message::new(vec![Destination::new("123456789012")]);
     message.regional = Some(regional);
     let request_body = SendRequestBody::new(vec![message]);
 
@@ -92,8 +92,8 @@ fn send_request_body_no_principal_entity_id() {
 #[test]
 fn send_request_body_no_turkey_recipient_type() {
     let mut regional = RegionalOptions::new();
-    regional.turkey_iys = Some(TurkeyIys::new("".to_string()));
-    let mut message = Message::new(vec![Destination::new("123456789012".to_string())]);
+    regional.turkey_iys = Some(TurkeyIys::new(""));
+    let mut message = Message::new(vec![Destination::new("123456789012")]);
     message.regional = Some(regional);
     let request_body = SendRequestBody::new(vec![message]);
 
@@ -103,8 +103,8 @@ fn send_request_body_no_turkey_recipient_type() {
 #[test]
 fn send_request_body_bad_turkey_recipient_type() {
     let mut regional = RegionalOptions::new();
-    regional.turkey_iys = Some(TurkeyIys::new("BAD".to_string()));
-    let mut message = Message::new(vec![Destination::new("123456789012".to_string())]);
+    regional.turkey_iys = Some(TurkeyIys::new("BAD"));
+    let mut message = Message::new(vec![Destination::new("123456789012")]);
     message.regional = Some(regional);
     let request_body = SendRequestBody::new(vec![message]);
 
@@ -133,7 +133,7 @@ fn message_from_str() {
 
 #[test]
 fn send_request_body_zero_speed_limit_amount() {
-    let message = Message::new(vec![Destination::new("123456789012".to_string())]);
+    let message = Message::new(vec![Destination::new("123456789012")]);
     let mut request_body = SendRequestBody::new(vec![message]);
     request_body.sending_speed_limit = Some(SpeedLimit::new(0));
 
@@ -142,7 +142,7 @@ fn send_request_body_zero_speed_limit_amount() {
 
 #[test]
 fn send_request_body_speed_limit_time_unit() {
-    let message = Message::new(vec![Destination::new("123456789012".to_string())]);
+    let message = Message::new(vec![Destination::new("123456789012")]);
     let mut speed_limit = SpeedLimit::new(5);
     speed_limit.time_unit = Some(TimeUnit::DAY);
 
@@ -159,7 +159,7 @@ fn send_request_body_with_delivery_time_window() {
     let delivery_time_window =
         DeliveryTimeWindow::new(vec![DeliveryDay::MONDAY, DeliveryDay::TUESDAY]);
 
-    let mut message = Message::new(vec![Destination::new("123456789012".to_string())]);
+    let mut message = Message::new(vec![Destination::new("123456789012")]);
     message.delivery_time_window = Some(delivery_time_window);
 
     let request_body = SendRequestBody::new(vec![message]);
@@ -173,7 +173,7 @@ fn send_request_body_with_delivery_time_window() {
 fn send_request_body_delivery_time_window_no_days() {
     let delivery_time_window = DeliveryTimeWindow::new(vec![]);
 
-    let mut message = Message::new(vec![Destination::new("123456789012".to_string())]);
+    let mut message = Message::new(vec![Destination::new("123456789012")]);
     message.delivery_time_window = Some(delivery_time_window);
 
     let request_body = SendRequestBody::new(vec![message]);
@@ -186,7 +186,7 @@ fn send_request_body_delivery_time_window_to_hour() {
     let mut delivery_time_window = DeliveryTimeWindow::new(vec![DeliveryDay::MONDAY]);
     delivery_time_window.to = Some(DeliveryTime::new(23, 59));
 
-    let mut message = Message::new(vec![Destination::new("123456789012".to_string())]);
+    let mut message = Message::new(vec![Destination::new("123456789012")]);
     message.delivery_time_window = Some(delivery_time_window);
 
     let request_body = SendRequestBody::new(vec![message]);
@@ -199,7 +199,7 @@ fn send_request_body_delivery_time_window_bad_to_hour() {
     let mut delivery_time_window = DeliveryTimeWindow::new(vec![DeliveryDay::MONDAY]);
     delivery_time_window.to = Some(DeliveryTime::new(24, 0));
 
-    let mut message = Message::new(vec![Destination::new("123456789012".to_string())]);
+    let mut message = Message::new(vec![Destination::new("123456789012")]);
     message.delivery_time_window = Some(delivery_time_window);
 
     let request_body = SendRequestBody::new(vec![message]);
@@ -212,7 +212,7 @@ fn send_request_body_delivery_time_window_bad_to_minute() {
     let mut delivery_time_window = DeliveryTimeWindow::new(vec![DeliveryDay::MONDAY]);
     delivery_time_window.to = Some(DeliveryTime::new(23, 60));
 
-    let mut message = Message::new(vec![Destination::new("123456789012".to_string())]);
+    let mut message = Message::new(vec![Destination::new("123456789012")]);
     message.delivery_time_window = Some(delivery_time_window);
 
     let request_body = SendRequestBody::new(vec![message]);
@@ -225,7 +225,7 @@ fn send_request_body_delivery_time_window_from_hour() {
     let mut delivery_time_window = DeliveryTimeWindow::new(vec![DeliveryDay::MONDAY]);
     delivery_time_window.from = Some(DeliveryTime::new(23, 59));
 
-    let mut message = Message::new(vec![Destination::new("123456789012".to_string())]);
+    let mut message = Message::new(vec![Destination::new("123456789012")]);
     message.delivery_time_window = Some(delivery_time_window);
 
     let request_body = SendRequestBody::new(vec![message]);
@@ -238,7 +238,7 @@ fn send_request_body_delivery_time_window_bad_from_hour() {
     let mut delivery_time_window = DeliveryTimeWindow::new(vec![DeliveryDay::MONDAY]);
     delivery_time_window.from = Some(DeliveryTime::new(24, 0));
 
-    let mut message = Message::new(vec![Destination::new("123456789012".to_string())]);
+    let mut message = Message::new(vec![Destination::new("123456789012")]);
     message.delivery_time_window = Some(delivery_time_window);
 
     let request_body = SendRequestBody::new(vec![message]);
@@ -251,7 +251,7 @@ fn send_request_body_delivery_time_window_bad_from_minute() {
     let mut delivery_time_window = DeliveryTimeWindow::new(vec![DeliveryDay::MONDAY]);
     delivery_time_window.from = Some(DeliveryTime::new(23, 60));
 
-    let mut message = Message::new(vec![Destination::new("123456789012".to_string())]);
+    let mut message = Message::new(vec![Destination::new("123456789012")]);
     message.delivery_time_window = Some(delivery_time_window);
 
     let request_body = SendRequestBody::new(vec![message]);
@@ -261,7 +261,7 @@ fn send_request_body_delivery_time_window_bad_from_minute() {
 
 #[test]
 fn send_request_body_long_callback_data() {
-    let mut message = Message::new(vec![Destination::new("123456789012".to_string())]);
+    let mut message = Message::new(vec![Destination::new("123456789012")]);
     message.callback_data = Some("longstring ".repeat(1000));
 
     let request_body = SendRequestBody::new(vec![message]);
@@ -271,7 +271,7 @@ fn send_request_body_long_callback_data() {
 
 #[test]
 fn send_binary_request_body_long_to() {
-    let message = BinaryMessage::new(vec![Destination::new("123456789012".repeat(10))]);
+    let message = BinaryMessage::new(vec![Destination::new(&"123456789012".repeat(10))]);
 
     let request_body = SendBinaryRequestBody::new(vec![message]);
 
@@ -280,8 +280,8 @@ fn send_binary_request_body_long_to() {
 
 #[test]
 fn send_binary_request_body_empty_hex() {
-    let binary_data = BinaryData::new("".to_string());
-    let mut message = BinaryMessage::new(vec![Destination::new("123456789012".to_string())]);
+    let binary_data = BinaryData::new("");
+    let mut message = BinaryMessage::new(vec![Destination::new("123456789012")]);
     message.binary = Some(binary_data);
 
     let request_body = SendBinaryRequestBody::new(vec![message]);
@@ -291,28 +291,28 @@ fn send_binary_request_body_empty_hex() {
 
 #[test]
 fn reschedule_request_body_valid() {
-    let request_body = RescheduleRequestBody::new("2021-08-25T16:00:00.000+0000".to_string());
+    let request_body = RescheduleRequestBody::new("2021-08-25T16:00:00.000+0000");
 
     assert!(request_body.validate().is_ok());
 }
 
 #[test]
 fn reschedule_request_body_empty_send_at() {
-    let request_body = RescheduleRequestBody::new("".to_string());
+    let request_body = RescheduleRequestBody::new("");
 
     assert!(request_body.validate().is_err());
 }
 
 #[test]
 fn get_scheduled_query_parameters_valid() {
-    let query_parameters = GetScheduledQueryParameters::new("some_bulk_id".to_string());
+    let query_parameters = GetScheduledQueryParameters::new("some_bulk_id");
 
     assert!(query_parameters.validate().is_ok());
 }
 
 #[test]
 fn get_scheduled_query_parameters_empty_bulk_id() {
-    let query_parameters = GetScheduledQueryParameters::new("".to_string());
+    let query_parameters = GetScheduledQueryParameters::new("");
 
     assert!(query_parameters.validate().is_err());
 }
@@ -335,39 +335,37 @@ fn get_inbound_reports_query_parameters_big_limit() {
 
 #[test]
 fn create_tfa_application_request_body_valid() {
-    let request_body = CreateTfaApplicationRequestBody::new("some_name".to_string());
+    let request_body = CreateTfaApplicationRequestBody::new("some_name");
 
     assert!(request_body.validate().is_ok());
 }
 
 #[test]
 fn create_tfa_application_request_body_empty_name() {
-    let request_body = CreateTfaApplicationRequestBody::new("".to_string());
+    let request_body = CreateTfaApplicationRequestBody::new("");
 
     assert!(request_body.validate().is_err());
 }
 
 #[test]
 fn create_tfa_message_template_request_body_valid() {
-    let request_body =
-        CreateTfaMessageTemplateRequestBody::new("some_name".to_string(), PinType::Alpha, 6);
+    let request_body = CreateTfaMessageTemplateRequestBody::new("some_name", PinType::Alpha, 6);
 
     assert!(request_body.validate().is_ok());
 }
 
 #[test]
 fn create_tfa_message_template_request_body_empty_name() {
-    let request_body = CreateTfaMessageTemplateRequestBody::new("".to_string(), PinType::Alpha, 6);
+    let request_body = CreateTfaMessageTemplateRequestBody::new("", PinType::Alpha, 6);
 
     assert!(request_body.validate().is_err());
 }
 
 #[test]
 fn create_tfa_message_template_request_body_no_principal_entity_id() {
-    let mut request_body =
-        CreateTfaMessageTemplateRequestBody::new("some_name".to_string(), PinType::Alpha, 6);
+    let mut request_body = CreateTfaMessageTemplateRequestBody::new("some_name", PinType::Alpha, 6);
     let regional = TfaRegional {
-        india_dlt: Some(IndiaDlt::new("".to_string())),
+        india_dlt: Some(IndiaDlt::new("")),
     };
     request_body.regional = Some(regional);
 
@@ -376,10 +374,9 @@ fn create_tfa_message_template_request_body_no_principal_entity_id() {
 
 #[test]
 fn update_tfa_message_template_request_body_no_principal_entity_id() {
-    let mut request_body =
-        UpdateTfaMessageTemplateRequestBody::new("some_name".to_string(), PinType::Alpha, 6);
+    let mut request_body = UpdateTfaMessageTemplateRequestBody::new("some_name", PinType::Alpha, 6);
     let regional = TfaRegional {
-        india_dlt: Some(IndiaDlt::new("".to_string())),
+        india_dlt: Some(IndiaDlt::new("")),
     };
     request_body.regional = Some(regional);
 
@@ -388,58 +385,43 @@ fn update_tfa_message_template_request_body_no_principal_entity_id() {
 
 #[test]
 fn send_pin_over_sms_request_body_valid() {
-    let request_body = SendPinOverSmsRequestBody::new(
-        "some-app-id".to_string(),
-        "some-message-id".to_string(),
-        "555555555555".to_string(),
-    );
+    let request_body =
+        SendPinOverSmsRequestBody::new("some-app-id", "some-message-id", "555555555555");
 
     assert!(request_body.validate().is_ok());
 }
 
 #[test]
 fn send_pin_over_sms_request_body_empty_app_id() {
-    let request_body = SendPinOverSmsRequestBody::new(
-        "".to_string(),
-        "some-message-id".to_string(),
-        "555555555555".to_string(),
-    );
+    let request_body = SendPinOverSmsRequestBody::new("", "some-message-id", "555555555555");
 
     assert!(request_body.validate().is_err());
 }
 
 #[test]
 fn send_pin_over_sms_request_body_empty_message_id() {
-    let request_body = SendPinOverSmsRequestBody::new(
-        "some-app-id".to_string(),
-        "".to_string(),
-        "555555555555".to_string(),
-    );
+    let request_body = SendPinOverSmsRequestBody::new("some-app-id", "", "555555555555");
 
     assert!(request_body.validate().is_err());
 }
 
 #[test]
 fn send_pin_over_sms_request_body_empty_to() {
-    let request_body = SendPinOverSmsRequestBody::new(
-        "some-app-id".to_string(),
-        "some-message-id".to_string(),
-        "".to_string(),
-    );
+    let request_body = SendPinOverSmsRequestBody::new("some-app-id", "some-message-id", "");
 
     assert!(request_body.validate().is_err());
 }
 
 #[test]
 fn verify_phone_number_request_body_valid() {
-    let request_body = VerifyPhoneNumberRequestBody::new("1234".to_string());
+    let request_body = VerifyPhoneNumberRequestBody::new("1234");
 
     assert!(request_body.validate().is_ok());
 }
 
 #[test]
 fn verify_phone_number_request_body_empty_pin() {
-    let request_body = VerifyPhoneNumberRequestBody::new("".to_string());
+    let request_body = VerifyPhoneNumberRequestBody::new("");
 
     assert!(request_body.validate().is_err());
 }

--- a/src/model/tests/sms.rs
+++ b/src/model/tests/sms.rs
@@ -332,3 +332,114 @@ fn get_inbound_reports_query_parameters_big_limit() {
 
     assert!(query_parameters.validate().is_err());
 }
+
+#[test]
+fn create_tfa_application_request_body_valid() {
+    let request_body = CreateTfaApplicationRequestBody::new("some_name".to_string());
+
+    assert!(request_body.validate().is_ok());
+}
+
+#[test]
+fn create_tfa_application_request_body_empty_name() {
+    let request_body = CreateTfaApplicationRequestBody::new("".to_string());
+
+    assert!(request_body.validate().is_err());
+}
+
+#[test]
+fn create_tfa_message_template_request_body_valid() {
+    let request_body =
+        CreateTfaMessageTemplateRequestBody::new("some_name".to_string(), PinType::Alpha, 6);
+
+    assert!(request_body.validate().is_ok());
+}
+
+#[test]
+fn create_tfa_message_template_request_body_empty_name() {
+    let request_body = CreateTfaMessageTemplateRequestBody::new("".to_string(), PinType::Alpha, 6);
+
+    assert!(request_body.validate().is_err());
+}
+
+#[test]
+fn create_tfa_message_template_request_body_no_principal_entity_id() {
+    let mut request_body =
+        CreateTfaMessageTemplateRequestBody::new("some_name".to_string(), PinType::Alpha, 6);
+    let regional = TfaRegional {
+        india_dlt: Some(IndiaDlt::new("".to_string())),
+    };
+    request_body.regional = Some(regional);
+
+    assert!(request_body.validate().is_err());
+}
+
+#[test]
+fn update_tfa_message_template_request_body_no_principal_entity_id() {
+    let mut request_body =
+        UpdateTfaMessageTemplateRequestBody::new("some_name".to_string(), PinType::Alpha, 6);
+    let regional = TfaRegional {
+        india_dlt: Some(IndiaDlt::new("".to_string())),
+    };
+    request_body.regional = Some(regional);
+
+    assert!(request_body.validate().is_err());
+}
+
+#[test]
+fn send_pin_over_sms_request_body_valid() {
+    let request_body = SendPinOverSmsRequestBody::new(
+        "some-app-id".to_string(),
+        "some-message-id".to_string(),
+        "555555555555".to_string(),
+    );
+
+    assert!(request_body.validate().is_ok());
+}
+
+#[test]
+fn send_pin_over_sms_request_body_empty_app_id() {
+    let request_body = SendPinOverSmsRequestBody::new(
+        "".to_string(),
+        "some-message-id".to_string(),
+        "555555555555".to_string(),
+    );
+
+    assert!(request_body.validate().is_err());
+}
+
+#[test]
+fn send_pin_over_sms_request_body_empty_message_id() {
+    let request_body = SendPinOverSmsRequestBody::new(
+        "some-app-id".to_string(),
+        "".to_string(),
+        "555555555555".to_string(),
+    );
+
+    assert!(request_body.validate().is_err());
+}
+
+#[test]
+fn send_pin_over_sms_request_body_empty_to() {
+    let request_body = SendPinOverSmsRequestBody::new(
+        "some-app-id".to_string(),
+        "some-message-id".to_string(),
+        "".to_string(),
+    );
+
+    assert!(request_body.validate().is_err());
+}
+
+#[test]
+fn verify_phone_number_request_body_valid() {
+    let request_body = VerifyPhoneNumberRequestBody::new("1234".to_string());
+
+    assert!(request_body.validate().is_ok());
+}
+
+#[test]
+fn verify_phone_number_request_body_empty_pin() {
+    let request_body = VerifyPhoneNumberRequestBody::new("".to_string());
+
+    assert!(request_body.validate().is_err());
+}

--- a/src/model/tests/whatsapp.rs
+++ b/src/model/tests/whatsapp.rs
@@ -12,9 +12,7 @@ fn get_dummy_send_template_request_body() -> SendTemplateRequestBody {
             media_url: "https://some.url".to_string(),
             filename: "file.txt".to_string(),
         }),
-        buttons: Some(vec![TemplateButtonContent::new_url(
-            "https://some.url".to_string(),
-        )]),
+        buttons: Some(vec![TemplateButtonContent::new_url("https://some.url")]),
     };
     let content = TemplateContent {
         template_name: "template_name1".to_string(),
@@ -346,18 +344,14 @@ fn get_dummy_create_template_request_body() -> CreateTemplateRequestBody {
 #[test]
 fn send_template_request_body_valid() {
     let content = TemplateContent::new(
-        "template_name1".to_string(),
+        "template_name1",
         TemplateData::new(TemplateBodyContent::new(vec![
             "value1".to_string(),
             "value2".to_string(),
         ])),
-        TemplateLanguage::EnUs.to_string(),
+        &TemplateLanguage::EnUs.to_string(),
     );
-    let message = FailoverMessage::new(
-        "444444444444".to_string(),
-        "555555555555".to_string(),
-        content,
-    );
+    let message = FailoverMessage::new("444444444444", "555555555555", content);
     let request_body = SendTemplateRequestBody::new(vec![message]);
 
     assert!(request_body.validate().is_ok());
@@ -497,9 +491,9 @@ fn send_template_request_body_message_content_long_template_name() {
 #[test]
 fn send_text_request_body_valid() {
     let request_body = SendTextRequestBody::new(
-        "444444444444".to_string(),
-        "555555555555".to_string(),
-        TextContent::new("message text".to_string()),
+        "444444444444",
+        "555555555555",
+        TextContent::new("message text"),
     );
 
     assert!(request_body.validate().is_ok());
@@ -596,9 +590,9 @@ fn send_text_request_sms_content_long_text() {
 #[test]
 fn send_document_request_valid() {
     let request_body = SendDocumentRequestBody::new(
-        "444444444444".to_string(),
-        "555555555555".to_string(),
-        DocumentContent::new("https://some.url".to_string()),
+        "444444444444",
+        "555555555555",
+        DocumentContent::new("https://some.url"),
     );
 
     assert!(request_body.validate().is_ok());
@@ -650,9 +644,9 @@ fn send_document_request_content_long_file_name() {
 #[test]
 fn send_image_request_body_valid() {
     let request_body = SendImageRequestBody::new(
-        "444444444444".to_string(),
-        "555555555555".to_string(),
-        ImageContent::new("https://some.url".to_string()),
+        "444444444444",
+        "555555555555",
+        ImageContent::new("https://some.url"),
     );
 
     assert!(request_body.validate().is_ok());
@@ -695,9 +689,9 @@ fn send_image_request_content_long_caption() {
 #[test]
 fn send_audio_request_body_valid() {
     let request_body = SendAudioRequestBody::new(
-        "444444444444".to_string(),
-        "555555555555".to_string(),
-        AudioContent::new("https://some.url".to_string()),
+        "444444444444",
+        "555555555555",
+        AudioContent::new("https://some.url"),
     );
 
     assert!(request_body.validate().is_ok());
@@ -731,9 +725,9 @@ fn send_audio_request_content_invalid_media_url() {
 #[test]
 fn send_video_request_body_valid() {
     let request_body = SendVideoRequestBody::new(
-        "444444444444".to_string(),
-        "555555555555".to_string(),
-        VideoContent::new("https://some.url".to_string()),
+        "444444444444",
+        "555555555555",
+        VideoContent::new("https://some.url"),
     );
 
     assert!(request_body.validate().is_ok());
@@ -776,9 +770,9 @@ fn send_video_request_content_long_caption() {
 #[test]
 fn send_sticker_request_body_valid() {
     let request_body = SendStickerRequestBody::new(
-        "444444444444".to_string(),
-        "555555555555".to_string(),
-        StickerContent::new("https://some.url".to_string()),
+        "444444444444",
+        "555555555555",
+        StickerContent::new("https://some.url"),
     );
 
     assert!(request_body.validate().is_ok());
@@ -812,8 +806,8 @@ fn send_sticker_request_content_invalid_media_url() {
 #[test]
 fn send_location_request_body_valid() {
     let request_body = SendLocationRequestBody::new(
-        "444444444444".to_string(),
-        "555555555555".to_string(),
+        "444444444444",
+        "555555555555",
         LocationContent::new(1.0, 2.0),
     );
 
@@ -866,12 +860,9 @@ fn send_location_request_content_long_name() {
 #[test]
 fn send_contact_request_body_valid() {
     let request_body = SendContactRequestBody::new(
-        "444444444444".to_string(),
-        "555555555555".to_string(),
-        ContactContent::new(vec![Contact::new(ContactName::new(
-            "John".to_string(),
-            "John Doe".to_string(),
-        ))]),
+        "444444444444",
+        "555555555555",
+        ContactContent::new(vec![Contact::new(ContactName::new("John", "John Doe"))]),
     );
 
     assert!(request_body.validate().is_ok());
@@ -895,12 +886,12 @@ fn send_contact_request_content_no_contacts() {
 
 #[test]
 fn send_interactive_buttons_request_body_valid() {
-    let button = InteractiveButton::new_reply_button("1".to_string(), "Button Title".to_string());
+    let button = InteractiveButton::new_reply_button("1", "Button Title");
     let request_body = SendInteractiveButtonsRequestBody::new(
-        "444444444444".to_string(),
-        "555555555555".to_string(),
+        "444444444444",
+        "555555555555",
         InteractiveButtonsContent::new(
-            InteractiveBody::new("Hello".to_string()),
+            InteractiveBody::new("Hello"),
             InteractiveButtonsAction::new(vec![button]),
         ),
     );
@@ -946,7 +937,7 @@ fn send_interactive_buttons_request_content_no_buttons() {
 fn send_interactive_buttons_request_content_no_footer_text() {
     let mut request_body = get_dummy_send_interactive_buttons_request_body();
 
-    request_body.content.footer = Some(InteractiveFooter::new("".to_string()));
+    request_body.content.footer = Some(InteractiveFooter::new(""));
 
     assert!(request_body.validate().is_err());
 }
@@ -955,21 +946,21 @@ fn send_interactive_buttons_request_content_no_footer_text() {
 fn send_interactive_buttons_request_content_long_footer_text() {
     let mut request_body = get_dummy_send_interactive_buttons_request_body();
 
-    request_body.content.footer = Some(InteractiveFooter::new("t".repeat(61usize)));
+    request_body.content.footer = Some(InteractiveFooter::new(&"t".repeat(61usize)));
 
     assert!(request_body.validate().is_err());
 }
 
 #[test]
 fn send_interactive_list_request_body_valid() {
-    let row = InteractiveRow::new("id1".to_string(), "title1".to_string());
+    let row = InteractiveRow::new("id1", "title1");
     let section = InteractiveListSection::new(vec![row]);
     let request_body = SendInteractiveListRequestBody::new(
-        "444444444444".to_string(),
-        "555555555555".to_string(),
+        "444444444444",
+        "555555555555",
         InteractiveListContent::new(
-            InteractiveBody::new("Hello".to_string()),
-            InteractiveListAction::new("Action Title".to_string(), vec![section]),
+            InteractiveBody::new("Hello"),
+            InteractiveListAction::new("Action Title", vec![section]),
         ),
     );
 
@@ -1033,50 +1024,17 @@ fn send_interactive_list_request_content_many_sections() {
     let mut request_body = get_dummy_send_interactive_list_request_body();
 
     request_body.content.action.sections = vec![
-        InteractiveListSection::new(vec![InteractiveRow::new(
-            "id1".to_string(),
-            "title1".to_string(),
-        )]),
-        InteractiveListSection::new(vec![InteractiveRow::new(
-            "id2".to_string(),
-            "title2".to_string(),
-        )]),
-        InteractiveListSection::new(vec![InteractiveRow::new(
-            "id3".to_string(),
-            "title3".to_string(),
-        )]),
-        InteractiveListSection::new(vec![InteractiveRow::new(
-            "id4".to_string(),
-            "title4".to_string(),
-        )]),
-        InteractiveListSection::new(vec![InteractiveRow::new(
-            "id5".to_string(),
-            "title5".to_string(),
-        )]),
-        InteractiveListSection::new(vec![InteractiveRow::new(
-            "id6".to_string(),
-            "title6".to_string(),
-        )]),
-        InteractiveListSection::new(vec![InteractiveRow::new(
-            "id7".to_string(),
-            "title7".to_string(),
-        )]),
-        InteractiveListSection::new(vec![InteractiveRow::new(
-            "id8".to_string(),
-            "title8".to_string(),
-        )]),
-        InteractiveListSection::new(vec![InteractiveRow::new(
-            "id9".to_string(),
-            "title9".to_string(),
-        )]),
-        InteractiveListSection::new(vec![InteractiveRow::new(
-            "id10".to_string(),
-            "title10".to_string(),
-        )]),
-        InteractiveListSection::new(vec![InteractiveRow::new(
-            "id11".to_string(),
-            "title11".to_string(),
-        )]),
+        InteractiveListSection::new(vec![InteractiveRow::new("id1", "title1")]),
+        InteractiveListSection::new(vec![InteractiveRow::new("id2", "title2")]),
+        InteractiveListSection::new(vec![InteractiveRow::new("id3", "title3")]),
+        InteractiveListSection::new(vec![InteractiveRow::new("id4", "title4")]),
+        InteractiveListSection::new(vec![InteractiveRow::new("id5", "title5")]),
+        InteractiveListSection::new(vec![InteractiveRow::new("id6", "title6")]),
+        InteractiveListSection::new(vec![InteractiveRow::new("id7", "title7")]),
+        InteractiveListSection::new(vec![InteractiveRow::new("id8", "title8")]),
+        InteractiveListSection::new(vec![InteractiveRow::new("id9", "title9")]),
+        InteractiveListSection::new(vec![InteractiveRow::new("id10", "title10")]),
+        InteractiveListSection::new(vec![InteractiveRow::new("id11", "title11")]),
     ];
 
     assert!(request_body.validate().is_err());
@@ -1140,7 +1098,7 @@ fn send_interactive_list_request_content_long_row_description() {
 fn send_interactive_list_request_content_no_footer_text() {
     let mut request_body = get_dummy_send_interactive_list_request_body();
 
-    request_body.content.footer = Some(InteractiveFooter::new("".to_string()));
+    request_body.content.footer = Some(InteractiveFooter::new(""));
 
     assert!(request_body.validate().is_err());
 }
@@ -1149,7 +1107,7 @@ fn send_interactive_list_request_content_no_footer_text() {
 fn send_interactive_list_request_content_long_footer_text() {
     let mut request_body = get_dummy_send_interactive_list_request_body();
 
-    request_body.content.footer = Some(InteractiveFooter::new("t".repeat(61usize)));
+    request_body.content.footer = Some(InteractiveFooter::new(&"t".repeat(61usize)));
 
     assert!(request_body.validate().is_err());
 }
@@ -1157,12 +1115,9 @@ fn send_interactive_list_request_content_long_footer_text() {
 #[test]
 fn send_interactive_product_request_valid() {
     let request_body = SendInteractiveProductRequestBody::new(
-        "555555555555".to_string(),
-        "444444444444".to_string(),
-        InteractiveProductContent::new(InteractiveProductAction::new(
-            "1".to_string(),
-            "2".to_string(),
-        )),
+        "555555555555",
+        "444444444444",
+        InteractiveProductContent::new(InteractiveProductAction::new("1", "2")),
     );
 
     assert!(request_body.validate().is_ok());
@@ -1197,24 +1152,24 @@ fn send_interactive_product_request_content_no_product_retailer_id() {
 fn send_interactive_product_request_content_no_footer_text() {
     let mut request_body = get_dummy_send_interactive_product_request_body();
 
-    request_body.content.footer = Some(InteractiveFooter::new("".to_string()));
+    request_body.content.footer = Some(InteractiveFooter::new(""));
 
     assert!(request_body.validate().is_err());
 }
 
 #[test]
 fn send_interactive_multiproduct_request_body_valid() {
-    let body = InteractiveBody::new("body text".to_string());
+    let body = InteractiveBody::new("body text");
 
     let section = InteractiveMultiproductSection::new(vec!["1".to_string(), "2".to_string()]);
 
-    let action = InteractiveMultiproductAction::new("1".to_string(), vec![section]);
+    let action = InteractiveMultiproductAction::new("1", vec![section]);
 
     let request_body = SendInteractiveMultiproductRequestBody::new(
-        "555555555555".to_string(),
-        "444444444444".to_string(),
+        "555555555555",
+        "444444444444",
         InteractiveMultiproductContent::new(
-            InteractiveMultiproductHeader::new_text_header("header text".to_string()),
+            InteractiveMultiproductHeader::new_text_header("header text"),
             body,
             action,
         ),
@@ -1234,7 +1189,7 @@ fn send_interactive_multiproduct_request_body_full_valid() {
 fn send_interactive_multiproduct_request_body_content_no_body_text() {
     let mut request_body = get_dummy_send_interactive_multiproduct_request_body();
 
-    request_body.content.body = InteractiveBody::new("".to_string());
+    request_body.content.body = InteractiveBody::new("");
 
     assert!(request_body.validate().is_err());
 }
@@ -1243,7 +1198,7 @@ fn send_interactive_multiproduct_request_body_content_no_body_text() {
 fn send_interactive_multiproduct_request_body_content_long_body_text() {
     let mut request_body = get_dummy_send_interactive_multiproduct_request_body();
 
-    request_body.content.body = InteractiveBody::new("t".repeat(1025usize));
+    request_body.content.body = InteractiveBody::new(&"t".repeat(1025usize));
 
     assert!(request_body.validate().is_err());
 }
@@ -1299,9 +1254,9 @@ fn send_interactive_multiproduct_request_body_content_action_section_long_title(
 
 #[test]
 fn create_template_request_body_valid() {
-    let structure = TemplateStructure::new(TemplateBody::new("hello".to_string()));
+    let structure = TemplateStructure::new(TemplateBody::new("hello"));
     let request_body = CreateTemplateRequestBody::new(
-        "rust_sdk_test_template".to_string(),
+        "rust_sdk_test_template",
         TemplateLanguage::EnUs,
         TemplateCategory::Marketing,
         structure,
@@ -1339,7 +1294,7 @@ fn create_template_request_body_structure_body_no_text() {
 fn create_template_request_body_structure_long_footer_text() {
     let mut request_body = get_dummy_create_template_request_body();
 
-    request_body.structure.footer = Some(TemplateFooter::new("t".repeat(61usize)));
+    request_body.structure.footer = Some(TemplateFooter::new(&"t".repeat(61usize)));
 
     assert!(request_body.validate().is_err());
 }
@@ -1349,10 +1304,10 @@ fn create_template_request_body_structure_many_buttons() {
     let mut request_body = get_dummy_create_template_request_body();
 
     request_body.structure.buttons = Some(vec![
-        TemplateButton::new_quick_reply("1".to_string()),
-        TemplateButton::new_quick_reply("1".to_string()),
-        TemplateButton::new_quick_reply("1".to_string()),
-        TemplateButton::new_quick_reply("1".to_string()),
+        TemplateButton::new_quick_reply("1"),
+        TemplateButton::new_quick_reply("1"),
+        TemplateButton::new_quick_reply("1"),
+        TemplateButton::new_quick_reply("1"),
     ]);
 
     assert!(request_body.validate().is_err());

--- a/src/model/whatsapp.rs
+++ b/src/model/whatsapp.rs
@@ -17,9 +17,9 @@ pub struct TextContent {
 }
 
 impl TextContent {
-    pub fn new(text: String) -> Self {
+    pub fn new(text: &str) -> Self {
         TextContent {
-            text,
+            text: text.into(),
             preview_url: None,
         }
     }
@@ -45,9 +45,9 @@ pub struct DocumentContent {
 }
 
 impl DocumentContent {
-    pub fn new(media_url: String) -> Self {
+    pub fn new(media_url: &str) -> Self {
         DocumentContent {
-            media_url,
+            media_url: media_url.into(),
             caption: None,
             filename: None,
         }
@@ -69,9 +69,9 @@ pub struct ImageContent {
 }
 
 impl ImageContent {
-    pub fn new(media_url: String) -> Self {
+    pub fn new(media_url: &str) -> Self {
         ImageContent {
-            media_url,
+            media_url: media_url.into(),
             caption: None,
         }
     }
@@ -88,8 +88,10 @@ pub struct AudioContent {
 }
 
 impl AudioContent {
-    pub fn new(media_url: String) -> Self {
-        AudioContent { media_url }
+    pub fn new(media_url: &str) -> Self {
+        AudioContent {
+            media_url: media_url.into(),
+        }
     }
 }
 
@@ -108,9 +110,9 @@ pub struct VideoContent {
 }
 
 impl VideoContent {
-    pub fn new(media_url: String) -> Self {
+    pub fn new(media_url: &str) -> Self {
         VideoContent {
-            media_url,
+            media_url: media_url.into(),
             caption: None,
         }
     }
@@ -127,8 +129,10 @@ pub struct StickerContent {
 }
 
 impl StickerContent {
-    pub fn new(media_url: String) -> Self {
-        StickerContent { media_url }
+    pub fn new(media_url: &str) -> Self {
+        StickerContent {
+            media_url: media_url.into(),
+        }
     }
 }
 
@@ -254,14 +258,14 @@ pub struct ContactName {
 }
 
 impl ContactName {
-    pub fn new(first_name: String, formatted_name: String) -> Self {
+    pub fn new(first_name: &str, formatted_name: &str) -> Self {
         ContactName {
-            first_name,
+            first_name: first_name.into(),
             last_name: None,
             middle_name: None,
             name_suffix: None,
             name_prefix: None,
-            formatted_name,
+            formatted_name: formatted_name.into(),
         }
     }
 }
@@ -457,10 +461,10 @@ pub struct SendContentRequestBody<T: serde::Serialize + Validate> {
 pub type SendTextRequestBody = SendContentRequestBody<TextContent>;
 
 impl SendTextRequestBody {
-    pub fn new(from: String, to: String, content: TextContent) -> Self {
+    pub fn new(from: &str, to: &str, content: TextContent) -> Self {
         SendTextRequestBody {
-            from,
-            to,
+            from: from.into(),
+            to: to.into(),
             message_id: None,
             content,
             callback_data: None,
@@ -472,10 +476,10 @@ impl SendTextRequestBody {
 pub type SendDocumentRequestBody = SendContentRequestBody<DocumentContent>;
 
 impl SendDocumentRequestBody {
-    pub fn new(from: String, to: String, content: DocumentContent) -> Self {
+    pub fn new(from: &str, to: &str, content: DocumentContent) -> Self {
         SendDocumentRequestBody {
-            from,
-            to,
+            from: from.into(),
+            to: to.into(),
             message_id: None,
             content,
             callback_data: None,
@@ -487,10 +491,10 @@ impl SendDocumentRequestBody {
 pub type SendImageRequestBody = SendContentRequestBody<ImageContent>;
 
 impl SendImageRequestBody {
-    pub fn new(from: String, to: String, content: ImageContent) -> Self {
+    pub fn new(from: &str, to: &str, content: ImageContent) -> Self {
         SendImageRequestBody {
-            from,
-            to,
+            from: from.into(),
+            to: to.into(),
             message_id: None,
             content,
             callback_data: None,
@@ -502,10 +506,10 @@ impl SendImageRequestBody {
 pub type SendAudioRequestBody = SendContentRequestBody<AudioContent>;
 
 impl SendAudioRequestBody {
-    pub fn new(from: String, to: String, content: AudioContent) -> Self {
+    pub fn new(from: &str, to: &str, content: AudioContent) -> Self {
         SendAudioRequestBody {
-            from,
-            to,
+            from: from.into(),
+            to: to.into(),
             message_id: None,
             content,
             callback_data: None,
@@ -517,10 +521,10 @@ impl SendAudioRequestBody {
 pub type SendVideoRequestBody = SendContentRequestBody<VideoContent>;
 
 impl SendVideoRequestBody {
-    pub fn new(from: String, to: String, content: VideoContent) -> Self {
+    pub fn new(from: &str, to: &str, content: VideoContent) -> Self {
         SendVideoRequestBody {
-            from,
-            to,
+            from: from.into(),
+            to: to.into(),
             message_id: None,
             content,
             callback_data: None,
@@ -532,10 +536,10 @@ impl SendVideoRequestBody {
 pub type SendStickerRequestBody = SendContentRequestBody<StickerContent>;
 
 impl SendStickerRequestBody {
-    pub fn new(from: String, to: String, content: StickerContent) -> Self {
+    pub fn new(from: &str, to: &str, content: StickerContent) -> Self {
         SendStickerRequestBody {
-            from,
-            to,
+            from: from.into(),
+            to: to.into(),
             message_id: None,
             content,
             callback_data: None,
@@ -547,10 +551,10 @@ impl SendStickerRequestBody {
 pub type SendLocationRequestBody = SendContentRequestBody<LocationContent>;
 
 impl SendLocationRequestBody {
-    pub fn new(from: String, to: String, content: LocationContent) -> Self {
+    pub fn new(from: &str, to: &str, content: LocationContent) -> Self {
         SendLocationRequestBody {
-            from,
-            to,
+            from: from.into(),
+            to: to.into(),
             message_id: None,
             content,
             callback_data: None,
@@ -562,10 +566,10 @@ impl SendLocationRequestBody {
 pub type SendContactRequestBody = SendContentRequestBody<ContactContent>;
 
 impl SendContactRequestBody {
-    pub fn new(from: String, to: String, content: ContactContent) -> Self {
+    pub fn new(from: &str, to: &str, content: ContactContent) -> Self {
         SendContactRequestBody {
-            from,
-            to,
+            from: from.into(),
+            to: to.into(),
             message_id: None,
             content,
             callback_data: None,
@@ -583,8 +587,8 @@ pub struct InteractiveBody {
 }
 
 impl InteractiveBody {
-    pub fn new(text: String) -> Self {
-        InteractiveBody { text }
+    pub fn new(text: &str) -> Self {
+        InteractiveBody { text: text.into() }
     }
 }
 
@@ -604,8 +608,11 @@ pub enum InteractiveButton {
 }
 
 impl InteractiveButton {
-    pub fn new_reply_button(id: String, title: String) -> Self {
-        InteractiveButton::ReplyButton { id, title }
+    pub fn new_reply_button(id: &str, title: &str) -> Self {
+        InteractiveButton::ReplyButton {
+            id: id.into(),
+            title: title.into(),
+        }
     }
 }
 
@@ -666,23 +673,27 @@ pub enum InteractiveButtonsHeader {
 }
 
 impl InteractiveButtonsHeader {
-    pub fn new_document_header(media_url: String, filename: Option<String>) -> Self {
+    pub fn new_document_header(media_url: &str, filename: Option<String>) -> Self {
         InteractiveButtonsHeader::DocumentHeader {
-            media_url,
+            media_url: media_url.into(),
             filename,
         }
     }
 
-    pub fn new_image_header(media_url: String) -> Self {
-        InteractiveButtonsHeader::ImageHeader { media_url }
+    pub fn new_image_header(media_url: &str) -> Self {
+        InteractiveButtonsHeader::ImageHeader {
+            media_url: media_url.into(),
+        }
     }
 
-    pub fn new_text_header(text: String) -> Self {
-        InteractiveButtonsHeader::TextHeader { text }
+    pub fn new_text_header(text: &str) -> Self {
+        InteractiveButtonsHeader::TextHeader { text: text.into() }
     }
 
-    pub fn new_video_header(media_url: String) -> Self {
-        InteractiveButtonsHeader::VideoHeader { media_url }
+    pub fn new_video_header(media_url: &str) -> Self {
+        InteractiveButtonsHeader::VideoHeader {
+            media_url: media_url.into(),
+        }
     }
 }
 
@@ -695,8 +706,8 @@ pub struct InteractiveFooter {
 }
 
 impl InteractiveFooter {
-    pub fn new(text: String) -> Self {
-        InteractiveFooter { text }
+    pub fn new(text: &str) -> Self {
+        InteractiveFooter { text: text.into() }
     }
 }
 
@@ -735,10 +746,10 @@ impl InteractiveButtonsContent {
 pub type SendInteractiveButtonsRequestBody = SendContentRequestBody<InteractiveButtonsContent>;
 
 impl SendInteractiveButtonsRequestBody {
-    pub fn new(from: String, to: String, content: InteractiveButtonsContent) -> Self {
+    pub fn new(from: &str, to: &str, content: InteractiveButtonsContent) -> Self {
         SendInteractiveButtonsRequestBody {
-            from,
-            to,
+            from: from.into(),
+            to: to.into(),
             message_id: None,
             content,
             callback_data: None,
@@ -766,10 +777,10 @@ pub struct InteractiveRow {
 }
 
 impl InteractiveRow {
-    pub fn new(id: String, title: String) -> Self {
+    pub fn new(id: &str, title: &str) -> Self {
         InteractiveRow {
-            id,
-            title,
+            id: id.into(),
+            title: title.into(),
             description: None,
         }
     }
@@ -809,8 +820,11 @@ pub struct InteractiveListAction {
 }
 
 impl InteractiveListAction {
-    pub fn new(title: String, sections: Vec<InteractiveListSection>) -> Self {
-        InteractiveListAction { title, sections }
+    pub fn new(title: &str, sections: Vec<InteractiveListSection>) -> Self {
+        InteractiveListAction {
+            title: title.into(),
+            sections,
+        }
     }
 }
 
@@ -825,8 +839,8 @@ pub enum InteractiveListHeader {
 }
 
 impl InteractiveListHeader {
-    pub fn new_text_header(text: String) -> Self {
-        InteractiveListHeader::TextHeader { text }
+    pub fn new_text_header(text: &str) -> Self {
+        InteractiveListHeader::TextHeader { text: text.into() }
     }
 }
 
@@ -866,10 +880,10 @@ impl InteractiveListContent {
 pub type SendInteractiveListRequestBody = SendContentRequestBody<InteractiveListContent>;
 
 impl SendInteractiveListRequestBody {
-    pub fn new(from: String, to: String, content: InteractiveListContent) -> Self {
+    pub fn new(from: &str, to: &str, content: InteractiveListContent) -> Self {
         SendInteractiveListRequestBody {
-            from,
-            to,
+            from: from.into(),
+            to: to.into(),
             message_id: None,
             content,
             callback_data: None,
@@ -892,10 +906,10 @@ pub struct InteractiveProductAction {
 }
 
 impl InteractiveProductAction {
-    pub fn new(catalog_id: String, product_retailer_id: String) -> Self {
+    pub fn new(catalog_id: &str, product_retailer_id: &str) -> Self {
         InteractiveProductAction {
-            catalog_id,
-            product_retailer_id,
+            catalog_id: catalog_id.into(),
+            product_retailer_id: product_retailer_id.into(),
         }
     }
 }
@@ -929,10 +943,10 @@ impl InteractiveProductContent {
 pub type SendInteractiveProductRequestBody = SendContentRequestBody<InteractiveProductContent>;
 
 impl SendInteractiveProductRequestBody {
-    pub fn new(from: String, to: String, content: InteractiveProductContent) -> Self {
+    pub fn new(from: &str, to: &str, content: InteractiveProductContent) -> Self {
         SendInteractiveProductRequestBody {
-            from,
-            to,
+            from: from.into(),
+            to: to.into(),
             message_id: None,
             content,
             callback_data: None,
@@ -952,8 +966,8 @@ pub enum InteractiveMultiproductHeader {
 }
 
 impl InteractiveMultiproductHeader {
-    pub fn new_text_header(text: String) -> Self {
-        InteractiveMultiproductHeader::TextHeader { text }
+    pub fn new_text_header(text: &str) -> Self {
+        InteractiveMultiproductHeader::TextHeader { text: text.into() }
     }
 }
 
@@ -994,9 +1008,9 @@ pub struct InteractiveMultiproductAction {
 }
 
 impl InteractiveMultiproductAction {
-    pub fn new(catalog_id: String, sections: Vec<InteractiveMultiproductSection>) -> Self {
+    pub fn new(catalog_id: &str, sections: Vec<InteractiveMultiproductSection>) -> Self {
         InteractiveMultiproductAction {
-            catalog_id,
+            catalog_id: catalog_id.into(),
             sections,
         }
     }
@@ -1040,10 +1054,10 @@ pub type SendInteractiveMultiproductRequestBody =
     SendContentRequestBody<InteractiveMultiproductContent>;
 
 impl SendInteractiveMultiproductRequestBody {
-    pub fn new(from: String, to: String, content: InteractiveMultiproductContent) -> Self {
+    pub fn new(from: &str, to: &str, content: InteractiveMultiproductContent) -> Self {
         SendInteractiveMultiproductRequestBody {
-            from,
-            to,
+            from: from.into(),
+            to: to.into(),
             message_id: None,
             content,
             callback_data: None,
@@ -1352,28 +1366,28 @@ pub enum TemplateHeader {
 }
 
 impl TemplateHeader {
-    pub fn new_text(text: String) -> Self {
+    pub fn new_text(text: &str) -> Self {
         Self::Text {
-            text,
+            text: text.into(),
             example: None,
         }
     }
 
-    pub fn new_image(example: String) -> Self {
+    pub fn new_image(example: &str) -> Self {
         Self::Image {
-            example: Some(example),
+            example: Some(example.into()),
         }
     }
 
-    pub fn new_video(example: String) -> Self {
+    pub fn new_video(example: &str) -> Self {
         Self::Video {
-            example: Some(example),
+            example: Some(example.into()),
         }
     }
 
-    pub fn new_document(example: String) -> Self {
+    pub fn new_document(example: &str) -> Self {
         Self::Document {
-            example: Some(example),
+            example: Some(example.into()),
         }
     }
 
@@ -1391,8 +1405,8 @@ pub struct TemplateFooter {
 }
 
 impl TemplateFooter {
-    pub fn new(text: String) -> Self {
-        TemplateFooter { text }
+    pub fn new(text: &str) -> Self {
+        TemplateFooter { text: text.into() }
     }
 }
 
@@ -1429,18 +1443,21 @@ pub enum TemplateButton {
 }
 
 impl TemplateButton {
-    pub fn new_number(text: String, phone_number: String) -> Self {
-        Self::Number { text, phone_number }
+    pub fn new_number(text: &str, phone_number: &str) -> Self {
+        Self::Number {
+            text: text.into(),
+            phone_number: phone_number.into(),
+        }
     }
 
-    pub fn new_quick_reply(text: String) -> Self {
-        Self::QuickReply { text }
+    pub fn new_quick_reply(text: &str) -> Self {
+        Self::QuickReply { text: text.into() }
     }
 
-    pub fn new_url(text: String, url: String) -> Self {
+    pub fn new_url(text: &str, url: &str) -> Self {
         Self::Url {
-            text,
-            url,
+            text: text.into(),
+            url: url.into(),
             example: None,
         }
     }
@@ -1461,9 +1478,9 @@ pub struct TemplateBody {
 }
 
 impl TemplateBody {
-    pub fn new(text: String) -> Self {
+    pub fn new(text: &str) -> Self {
         TemplateBody {
-            text,
+            text: text.into(),
             examples: None,
         }
     }
@@ -1534,13 +1551,13 @@ pub struct CreateTemplateRequestBody {
 
 impl CreateTemplateRequestBody {
     pub fn new(
-        name: String,
+        name: &str,
         language: TemplateLanguage,
         category: TemplateCategory,
         structure: TemplateStructure,
     ) -> Self {
         CreateTemplateRequestBody {
-            name,
+            name: name.into(),
             language,
             category,
             structure,
@@ -1598,15 +1615,17 @@ pub enum TemplateHeaderContent {
 }
 
 impl TemplateHeaderContent {
-    pub fn new_document(media_url: String, filename: String) -> Self {
+    pub fn new_document(media_url: &str, filename: &str) -> Self {
         TemplateHeaderContent::Document {
-            media_url,
-            filename,
+            media_url: media_url.into(),
+            filename: filename.into(),
         }
     }
 
-    pub fn new_image(media_url: String) -> Self {
-        TemplateHeaderContent::Image { media_url }
+    pub fn new_image(media_url: &str) -> Self {
+        TemplateHeaderContent::Image {
+            media_url: media_url.into(),
+        }
     }
 
     pub fn new_location(latitude: f64, longitude: f64) -> Self {
@@ -1616,12 +1635,16 @@ impl TemplateHeaderContent {
         }
     }
 
-    pub fn new_text(placeholder: String) -> Self {
-        TemplateHeaderContent::Text { placeholder }
+    pub fn new_text(placeholder: &str) -> Self {
+        TemplateHeaderContent::Text {
+            placeholder: placeholder.into(),
+        }
     }
 
-    pub fn new_video(media_url: String) -> Self {
-        TemplateHeaderContent::Video { media_url }
+    pub fn new_video(media_url: &str) -> Self {
+        TemplateHeaderContent::Video {
+            media_url: media_url.into(),
+        }
     }
 }
 
@@ -1658,12 +1681,16 @@ pub enum TemplateButtonContent {
 }
 
 impl TemplateButtonContent {
-    pub fn new_quick_reply(parameter: String) -> Self {
-        TemplateButtonContent::QuickReply { parameter }
+    pub fn new_quick_reply(parameter: &str) -> Self {
+        TemplateButtonContent::QuickReply {
+            parameter: parameter.into(),
+        }
     }
 
-    pub fn new_url(parameter: String) -> Self {
-        TemplateButtonContent::Url { parameter }
+    pub fn new_url(parameter: &str) -> Self {
+        TemplateButtonContent::Url {
+            parameter: parameter.into(),
+        }
     }
 }
 
@@ -1715,11 +1742,11 @@ pub struct TemplateContent {
 }
 
 impl TemplateContent {
-    pub fn new(template_name: String, template_data: TemplateData, language: String) -> Self {
+    pub fn new(template_name: &str, template_data: TemplateData, language: &str) -> Self {
         TemplateContent {
-            template_name,
+            template_name: template_name.into(),
             template_data,
-            language,
+            language: language.into(),
         }
     }
 }
@@ -1737,8 +1764,11 @@ pub struct SmsFailover {
 }
 
 impl SmsFailover {
-    pub fn new(from: String, text: String) -> Self {
-        SmsFailover { from, text }
+    pub fn new(from: &str, text: &str) -> Self {
+        SmsFailover {
+            from: from.into(),
+            text: text.into(),
+        }
     }
 }
 
@@ -1783,10 +1813,10 @@ pub struct FailoverMessage {
 }
 
 impl FailoverMessage {
-    pub fn new(from: String, to: String, content: TemplateContent) -> Self {
+    pub fn new(from: &str, to: &str, content: TemplateContent) -> Self {
         Self {
-            from,
-            to,
+            from: from.into(),
+            to: to.into(),
             content,
             message_id: None,
             callback_data: None,

--- a/src/model/whatsapp.rs
+++ b/src/model/whatsapp.rs
@@ -597,7 +597,7 @@ impl InteractiveBody {
 pub enum InteractiveButton {
     #[serde(rename = "REPLY")]
     ReplyButton {
-        /// Unique identifier of the button containing no leading nor trailing whitespaces.
+        /// Unique identifier of the button containing no leading nor trailing white spaces.
         #[serde(rename = "id")]
         id: String,
 

--- a/tests/email.rs
+++ b/tests/email.rs
@@ -31,7 +31,7 @@ fn get_test_to() -> String {
 #[ignore]
 #[tokio::test]
 async fn send() {
-    let mut request_body = SendRequestBody::new(get_test_to());
+    let mut request_body = SendRequestBody::new(&get_test_to());
     request_body.from = Some(get_test_from());
     request_body.subject = Some("Test subject".to_string());
     request_body.text = Some("Hello world!".to_string());
@@ -46,7 +46,7 @@ async fn send() {
 #[ignore]
 #[tokio::test]
 async fn send_bulk() {
-    let mut request_body = SendRequestBody::new(get_test_to());
+    let mut request_body = SendRequestBody::new(&get_test_to());
     request_body.from = Some(get_test_from());
     request_body.subject = Some("Test subject".to_string());
     request_body.text = Some("Hello world!".to_string());
@@ -62,7 +62,7 @@ async fn send_bulk() {
 #[ignore]
 #[tokio::test]
 async fn get_bulks() {
-    let query_params = GetBulksQueryParameters::new("test-bulk-id-rust-003".to_string());
+    let query_params = GetBulksQueryParameters::new("test-bulk-id-rust-003");
 
     let response = get_test_email_client()
         .get_bulks(query_params)
@@ -75,9 +75,9 @@ async fn get_bulks() {
 #[ignore]
 #[tokio::test]
 async fn reschedule() {
-    let query_params = RescheduleQueryParameters::new("test-bulk-id-rust-003".to_string());
-    let send_at = "2022-10-05T17:29:52Z".to_string();
-    let expected_send_at = DateTime::parse_from_rfc3339(&send_at)
+    let query_params = RescheduleQueryParameters::new("test-bulk-id-rust-003");
+    let send_at = "2022-10-05T17:29:52Z";
+    let expected_send_at = DateTime::parse_from_rfc3339(send_at)
         .unwrap()
         .timestamp_millis();
 
@@ -95,7 +95,7 @@ async fn reschedule() {
 #[ignore]
 #[tokio::test]
 async fn get_scheduled_status() {
-    let query_params = GetScheduledStatusQueryParameters::new("test-bulk-id-rust-003".to_string());
+    let query_params = GetScheduledStatusQueryParameters::new("test-bulk-id-rust-003");
 
     let response = get_test_email_client()
         .get_scheduled_status(query_params)
@@ -109,7 +109,7 @@ async fn get_scheduled_status() {
 #[tokio::test]
 async fn update_scheduled_status() {
     let query_params =
-        UpdateScheduledStatusQueryParameters::new("test-bulk-id-rust-003".to_string());
+        UpdateScheduledStatusQueryParameters::new("test-bulk-id-rust-003");
     let request_body = UpdateScheduledStatusRequestBody::new(BulkStatus::CANCELED);
 
     let response = get_test_email_client()
@@ -150,7 +150,7 @@ async fn get_logs() {
 #[ignore]
 #[tokio::test]
 async fn validate_address() {
-    let query_params = ValidateAddressRequestBody::new("someone@infobip.com".to_string());
+    let query_params = ValidateAddressRequestBody::new("someone@infobip.com");
 
     let response = get_test_email_client()
         .validate_address(query_params)
@@ -177,7 +177,7 @@ async fn get_domains() {
 #[ignore]
 #[tokio::test]
 async fn add_domain() {
-    let mut request_body = AddDomainRequestBody::new("test-domain-rust-001.com".to_string());
+    let mut request_body = AddDomainRequestBody::new("test-domain-rust-001.com");
     request_body.dkim_key_length = Some(L1024);
 
     let response = get_test_email_client()
@@ -193,7 +193,7 @@ async fn add_domain() {
 #[tokio::test]
 async fn get_domain() {
     let response = get_test_email_client()
-        .get_domain("test-domain-rust-001.com".to_string())
+        .get_domain("test-domain-rust-001.com")
         .await
         .unwrap();
 
@@ -205,7 +205,7 @@ async fn get_domain() {
 #[tokio::test]
 async fn delete_domain() {
     let status = get_test_email_client()
-        .delete_domain("test-domain-rust-001.com".to_string())
+        .delete_domain("test-domain-rust-001.com")
         .await
         .unwrap();
 
@@ -219,7 +219,7 @@ async fn update_tracking() {
     request_body.opens = Some(false);
 
     let response = get_test_email_client()
-        .update_tracking("test-domain-rust-001.com".to_string(), request_body)
+        .update_tracking("test-domain-rust-001.com", request_body)
         .await
         .unwrap();
 
@@ -231,7 +231,7 @@ async fn update_tracking() {
 #[tokio::test]
 async fn verify_domain() {
     let status = get_test_email_client()
-        .verify_domain("test-domain-rust-001.com".to_string())
+        .verify_domain("test-domain-rust-001.com")
         .await
         .unwrap();
 

--- a/tests/email.rs
+++ b/tests/email.rs
@@ -6,6 +6,7 @@
 
 use chrono::DateTime;
 use reqwest::StatusCode;
+use std::env;
 
 use infobip_sdk::api::email::EmailClient;
 use infobip_sdk::configuration;
@@ -14,17 +15,17 @@ use infobip_sdk::model::email::*;
 
 fn get_test_email_client() -> EmailClient {
     EmailClient::with_configuration(
-        configuration::Configuration::from_dotenv_api_key()
+        configuration::Configuration::from_env_api_key()
             .expect("failed to build default test client"),
     )
 }
 
 fn get_test_from() -> String {
-    dotenv::var("IB_TEST_EMAIL_FROM").expect("failed to load test email from")
+    env::var("IB_TEST_EMAIL_FROM").expect("failed to load test email from")
 }
 
 fn get_test_to() -> String {
-    dotenv::var("IB_TEST_EMAIL_TO").expect("failed to load test email to")
+    env::var("IB_TEST_EMAIL_TO").expect("failed to load test email to")
 }
 
 #[ignore]

--- a/tests/email.rs
+++ b/tests/email.rs
@@ -108,8 +108,7 @@ async fn get_scheduled_status() {
 #[ignore]
 #[tokio::test]
 async fn update_scheduled_status() {
-    let query_params =
-        UpdateScheduledStatusQueryParameters::new("test-bulk-id-rust-003");
+    let query_params = UpdateScheduledStatusQueryParameters::new("test-bulk-id-rust-003");
     let request_body = UpdateScheduledStatusRequestBody::new(BulkStatus::CANCELED);
 
     let response = get_test_email_client()

--- a/tests/sms.rs
+++ b/tests/sms.rs
@@ -363,3 +363,150 @@ async fn get_tfa_message_templates() {
     println!("{:?}", response.body);
     assert_eq!(response.status, StatusCode::OK);
 }
+
+#[ignore]
+#[tokio::test]
+async fn create_tfa_message_template() {
+    let request_body = CreateTfaMessageTemplateRequestBody::new(
+        "Your Rust PIN 2 is {{pin}}".to_string(),
+        PinType::Numeric,
+        6,
+    );
+
+    let response = get_test_sms_client()
+        .create_tfa_message_template("02CC3CAAFD733136AA15DFAC720A0C42", request_body)
+        .await
+        .unwrap();
+
+    println!("{:?}", response.body);
+    assert_eq!(response.status, StatusCode::OK);
+}
+
+#[ignore]
+#[tokio::test]
+async fn get_tfa_message_template() {
+    let response = get_test_sms_client()
+        .get_tfa_message_template(
+            "02CC3CAAFD733136AA15DFAC720A0C42",
+            "44A45DA3067F882BB4D87D6A48F9681E",
+        )
+        .await
+        .unwrap();
+
+    println!("{:?}", response.body);
+    assert_eq!(response.status, StatusCode::OK);
+}
+
+#[ignore]
+#[tokio::test]
+async fn update_tfa_message_template() {
+    let request_body = UpdateTfaMessageTemplateRequestBody::new(
+        "Your Rust PIN 3 is {{pin}}".to_string(),
+        PinType::Numeric,
+        6,
+    );
+
+    let response = get_test_sms_client()
+        .update_tfa_message_template(
+            "02CC3CAAFD733136AA15DFAC720A0C42",
+            "44A45DA3067F882BB4D87D6A48F9681E",
+            request_body,
+        )
+        .await
+        .unwrap();
+
+    println!("{:?}", response.body);
+    assert_eq!(response.status, StatusCode::OK);
+}
+
+#[ignore]
+#[tokio::test]
+async fn send_pin_over_sms() {
+    let query_parameters = SendPinOverSmsQueryParameters::new();
+    let request_body = SendPinOverSmsRequestBody::new(
+        "02CC3CAAFD733136AA15DFAC720A0C42".to_string(),
+        "44A45DA3067F882BB4D87D6A48F9681E".to_string(),
+        "523311800428".to_string(),
+    );
+
+    let response = get_test_sms_client()
+        .send_pin_over_sms(query_parameters, request_body)
+        .await
+        .unwrap();
+
+    println!("{:?}", response.body);
+    assert_eq!(response.status, StatusCode::OK);
+}
+
+#[ignore]
+#[tokio::test]
+async fn resend_pin_over_sms() {
+    let request_body = ResendPinOverSmsRequestBody::default();
+
+    let response = get_test_sms_client()
+        .resend_pin_over_sms("AAA30929B83F2ED86CC34781BCB7A546", request_body)
+        .await
+        .unwrap();
+
+    println!("{:?}", response.body);
+    assert_eq!(response.status, StatusCode::OK);
+}
+
+#[ignore]
+#[tokio::test]
+async fn send_pin_over_voice() {
+    let request_body = SendPinOverVoiceRequestBody::new(
+        "02CC3CAAFD733136AA15DFAC720A0C42".to_string(),
+        "44A45DA3067F882BB4D87D6A48F9681E".to_string(),
+        "523311800428".to_string(),
+    );
+
+    let response = get_test_sms_client()
+        .send_pin_over_voice(request_body)
+        .await
+        .unwrap();
+
+    println!("{:?}", response.body);
+    assert_eq!(response.status, StatusCode::OK);
+}
+
+#[ignore]
+#[tokio::test]
+async fn resend_pin_over_voice() {
+    let request_body = ResendPinOverVoiceRequestBody::default();
+
+    let response = get_test_sms_client()
+        .resend_pin_over_voice("AAA30929B83F2ED86CC34781BCB7A546", request_body)
+        .await
+        .unwrap();
+
+    println!("{:?}", response.body);
+    assert_eq!(response.status, StatusCode::OK);
+}
+
+#[ignore]
+#[tokio::test]
+async fn verify_phone_number() {
+    let request_body = VerifyPhoneNumberRequestBody::new("123456".to_string());
+
+    let response = get_test_sms_client()
+        .verify_phone_number("AAA30929B83F2ED86CC34781BCB7A546", request_body)
+        .await
+        .unwrap();
+
+    println!("{:?}", response.body);
+    assert_eq!(response.status, StatusCode::OK);
+}
+
+#[ignore]
+#[tokio::test]
+async fn get_tfa_verification_status() {
+    let query_parameters = GetTfaVerificationStatusQueryParameters::new("523311800428".to_string());
+    let response = get_test_sms_client()
+        .get_tfa_verification_status("02CC3CAAFD733136AA15DFAC720A0C42", query_parameters)
+        .await
+        .unwrap();
+
+    println!("{:?}", response.body);
+    assert_eq!(response.status, StatusCode::OK);
+}

--- a/tests/sms.rs
+++ b/tests/sms.rs
@@ -293,3 +293,73 @@ async fn update_scheduled_status() {
         .unwrap();
     assert_eq!(response.status, StatusCode::OK);
 }
+
+#[ignore]
+#[tokio::test]
+async fn get_tfa_applications() {
+    let response = get_test_sms_client().get_tfa_applications().await.unwrap();
+
+    println!("{:?}", response.body);
+    assert_eq!(response.status, StatusCode::OK);
+}
+
+#[ignore]
+#[tokio::test]
+async fn create_tfa_application() {
+    let request_body = CreateTfaApplicationRequestBody::new("rust-application".to_string());
+
+    let response = get_test_sms_client()
+        .create_tfa_application(request_body)
+        .await
+        .unwrap();
+
+    println!("{:?}", response.body);
+    assert_eq!(response.status, StatusCode::CREATED);
+}
+
+#[ignore]
+#[tokio::test]
+async fn get_tfa_application() {
+    let response = get_test_sms_client()
+        .get_tfa_application("02CC3CAAFD733136AA15DFAC720A0C42")
+        .await
+        .unwrap();
+
+    println!("{:?}", response.body);
+    assert_eq!(response.status, StatusCode::OK);
+}
+
+#[ignore]
+#[tokio::test]
+async fn update_tfa_application() {
+    let configuration = TfaApplicationConfiguration {
+        allow_multiple_pin_verifications: Some(true),
+        pin_attempts: None,
+        pin_time_to_live: None,
+        send_pin_per_application_limit: Some("5010/12h".to_string()),
+        send_pin_per_phone_number_limit: None,
+        verify_pin_limit: None,
+    };
+    let mut request_body = UpdateTfaApplicationRequestBody::new("rust-application-2".to_string());
+    request_body.configuration = Some(configuration);
+
+    let response = get_test_sms_client()
+        .update_tfa_application("02CC3CAAFD733136AA15DFAC720A0C42", request_body)
+        .await
+        .unwrap();
+
+    println!("{:?}", response.body);
+    assert_eq!(response.status, StatusCode::OK);
+}
+
+#[ignore]
+#[tokio::test]
+async fn get_tfa_message_templates() {
+    let response = get_test_sms_client()
+        .get_tfa_message_templates("02CC3CAAFD733136AA15DFAC720A0C42")
+        .await
+        .unwrap();
+
+    println!("{:?}", response.body);
+    assert_eq!(response.status, StatusCode::OK);
+}

--- a/tests/sms.rs
+++ b/tests/sms.rs
@@ -36,7 +36,7 @@ fn get_test_destination_number() -> String {
 #[ignore]
 #[tokio::test]
 async fn preview_sms() {
-    let request_body = PreviewRequestBody::new(DUMMY_TEXT.to_string());
+    let request_body = PreviewRequestBody::new(DUMMY_TEXT);
 
     let response = get_test_sms_client().preview(request_body).await.unwrap();
 
@@ -47,7 +47,7 @@ async fn preview_sms() {
 #[ignore]
 #[test]
 fn preview_sms_blocking() {
-    let request_body = PreviewRequestBody::new(DUMMY_TEXT.to_string());
+    let request_body = PreviewRequestBody::new(DUMMY_TEXT);
 
     let response = get_test_blocking_sms_client()
         .preview(request_body)
@@ -62,10 +62,10 @@ fn preview_sms_blocking() {
 async fn preview_sms_multiple() {
     let sms_client = get_test_sms_client();
 
-    let request_body1 = PreviewRequestBody::new(DUMMY_TEXT.to_string());
-    let request_body2 = PreviewRequestBody::new(DUMMY_TEXT.to_string());
-    let request_body3 = PreviewRequestBody::new(DUMMY_TEXT.to_string());
-    let request_body4 = PreviewRequestBody::new(DUMMY_TEXT.to_string());
+    let request_body1 = PreviewRequestBody::new(DUMMY_TEXT);
+    let request_body2 = PreviewRequestBody::new(DUMMY_TEXT);
+    let request_body3 = PreviewRequestBody::new(DUMMY_TEXT);
+    let request_body4 = PreviewRequestBody::new(DUMMY_TEXT);
 
     let (resp1, resp2, resp3, resp4) = tokio::join!(
         sms_client.preview(request_body1),
@@ -117,10 +117,10 @@ async fn preview_sms_multiple() {
 fn preview_sms_multiple_blocking() {
     let sms_client = get_test_blocking_sms_client();
 
-    let request_body1 = PreviewRequestBody::new(DUMMY_TEXT.to_string());
-    let request_body2 = PreviewRequestBody::new(DUMMY_TEXT.to_string());
-    let request_body3 = PreviewRequestBody::new(DUMMY_TEXT.to_string());
-    let request_body4 = PreviewRequestBody::new(DUMMY_TEXT.to_string());
+    let request_body1 = PreviewRequestBody::new(DUMMY_TEXT);
+    let request_body2 = PreviewRequestBody::new(DUMMY_TEXT);
+    let request_body3 = PreviewRequestBody::new(DUMMY_TEXT);
+    let request_body4 = PreviewRequestBody::new(DUMMY_TEXT);
 
     let response1 = sms_client.preview(request_body1).unwrap();
     let response2 = sms_client.preview(request_body2).unwrap();
@@ -154,8 +154,8 @@ async fn get_sms_delivery_reports() {
 #[ignore]
 #[tokio::test]
 async fn send_sms() {
-    let mut message = Message::new(vec![Destination::new(get_test_destination_number())]);
-    message.text = Some(DUMMY_TEXT.to_string());
+    let mut message = Message::new(vec![Destination::new(&get_test_destination_number())]);
+    message.text = Some(DUMMY_TEXT.into());
 
     let request_body = SendRequestBody::new(vec![message]);
 
@@ -168,12 +168,12 @@ async fn send_sms() {
 #[ignore]
 #[tokio::test]
 async fn send_bulk_sms() {
-    let mut message = Message::new(vec![Destination::new(get_test_destination_number())]);
-    message.text = Some(DUMMY_TEXT.to_string());
+    let mut message = Message::new(vec![Destination::new(&get_test_destination_number())]);
+    message.text = Some(DUMMY_TEXT.into());
     message.send_at = Some("2022-10-10T00:00:00Z".to_string());
 
     let mut request_body = SendRequestBody::new(vec![message]);
-    request_body.bulk_id = Some(DUMMY_BULK_ID.to_string());
+    request_body.bulk_id = Some(DUMMY_BULK_ID.into());
 
     let response = get_test_sms_client().send(request_body).await.unwrap();
 
@@ -184,8 +184,8 @@ async fn send_bulk_sms() {
 #[ignore]
 #[tokio::test]
 async fn send_binary_sms() {
-    let mut message = BinaryMessage::new(vec![Destination::new(get_test_destination_number())]);
-    message.binary = Some(BinaryData::new("0f c2 4a bf 34 13 ba".to_string()));
+    let mut message = BinaryMessage::new(vec![Destination::new(&get_test_destination_number())]);
+    message.binary = Some(BinaryData::new("0f c2 4a bf 34 13 ba"));
 
     let mut request_body = SendBinaryRequestBody::new(vec![message]);
     request_body.bulk_id = Some("test-bulk-id-5319".to_string());
@@ -227,11 +227,8 @@ async fn get_inbound_reports() {
 #[tokio::test]
 async fn send_over_query_parameters() {
     let destinations = vec!["31612345678".to_string(), "31698765432".to_string()];
-    let query_parameters = SendOverQueryParametersQueryParameters::new(
-        "username".to_string(),
-        "password".to_string(),
-        destinations,
-    );
+    let query_parameters =
+        SendOverQueryParametersQueryParameters::new("username", "password", destinations);
 
     let response = get_test_sms_client()
         .send_over_query_parameters(query_parameters)
@@ -244,7 +241,7 @@ async fn send_over_query_parameters() {
 #[ignore]
 #[tokio::test]
 async fn get_scheduled() {
-    let query_parameters = GetScheduledStatusQueryParameters::new(DUMMY_BULK_ID.to_string());
+    let query_parameters = GetScheduledStatusQueryParameters::new(DUMMY_BULK_ID);
 
     let response = get_test_sms_client()
         .get_scheduled_status(query_parameters)
@@ -257,7 +254,7 @@ async fn get_scheduled() {
 #[ignore]
 #[tokio::test]
 async fn get_scheduled_status() {
-    let query_parameters = GetScheduledStatusQueryParameters::new(DUMMY_BULK_ID.to_string());
+    let query_parameters = GetScheduledStatusQueryParameters::new(DUMMY_BULK_ID);
 
     let response = get_test_sms_client()
         .get_scheduled_status(query_parameters)
@@ -270,8 +267,8 @@ async fn get_scheduled_status() {
 #[ignore]
 #[tokio::test]
 async fn reschedule() {
-    let query_parameters = RescheduleQueryParameters::new(DUMMY_BULK_ID.to_string());
-    let request_body = RescheduleRequestBody::new("2022-10-02T00:00:00".to_string());
+    let query_parameters = RescheduleQueryParameters::new(DUMMY_BULK_ID);
+    let request_body = RescheduleRequestBody::new("2022-10-02T00:00:00");
 
     let response = get_test_sms_client()
         .reschedule(query_parameters, request_body)
@@ -284,7 +281,7 @@ async fn reschedule() {
 #[ignore]
 #[tokio::test]
 async fn update_scheduled_status() {
-    let query_parameters = UpdateScheduledStatusQueryParameters::new(DUMMY_BULK_ID.to_string());
+    let query_parameters = UpdateScheduledStatusQueryParameters::new(DUMMY_BULK_ID);
     let request_body = UpdateScheduledStatusRequestBody::new(ScheduledStatus::CANCELED);
 
     let response = get_test_sms_client()
@@ -306,7 +303,7 @@ async fn get_tfa_applications() {
 #[ignore]
 #[tokio::test]
 async fn create_tfa_application() {
-    let request_body = CreateTfaApplicationRequestBody::new("rust-application".to_string());
+    let request_body = CreateTfaApplicationRequestBody::new("rust-application");
 
     let response = get_test_sms_client()
         .create_tfa_application(request_body)
@@ -340,7 +337,7 @@ async fn update_tfa_application() {
         send_pin_per_phone_number_limit: None,
         verify_pin_limit: None,
     };
-    let mut request_body = UpdateTfaApplicationRequestBody::new("rust-application-2".to_string());
+    let mut request_body = UpdateTfaApplicationRequestBody::new("rust-application-2");
     request_body.configuration = Some(configuration);
 
     let response = get_test_sms_client()
@@ -367,11 +364,8 @@ async fn get_tfa_message_templates() {
 #[ignore]
 #[tokio::test]
 async fn create_tfa_message_template() {
-    let request_body = CreateTfaMessageTemplateRequestBody::new(
-        "Your Rust PIN 2 is {{pin}}".to_string(),
-        PinType::Numeric,
-        6,
-    );
+    let request_body =
+        CreateTfaMessageTemplateRequestBody::new("Your Rust PIN 2 is {{pin}}", PinType::Numeric, 6);
 
     let response = get_test_sms_client()
         .create_tfa_message_template("02CC3CAAFD733136AA15DFAC720A0C42", request_body)
@@ -400,11 +394,8 @@ async fn get_tfa_message_template() {
 #[ignore]
 #[tokio::test]
 async fn update_tfa_message_template() {
-    let request_body = UpdateTfaMessageTemplateRequestBody::new(
-        "Your Rust PIN 3 is {{pin}}".to_string(),
-        PinType::Numeric,
-        6,
-    );
+    let request_body =
+        UpdateTfaMessageTemplateRequestBody::new("Your Rust PIN 3 is {{pin}}", PinType::Numeric, 6);
 
     let response = get_test_sms_client()
         .update_tfa_message_template(
@@ -424,9 +415,9 @@ async fn update_tfa_message_template() {
 async fn send_pin_over_sms() {
     let query_parameters = SendPinOverSmsQueryParameters::new();
     let request_body = SendPinOverSmsRequestBody::new(
-        "02CC3CAAFD733136AA15DFAC720A0C42".to_string(),
-        "44A45DA3067F882BB4D87D6A48F9681E".to_string(),
-        "523311800428".to_string(),
+        "02CC3CAAFD733136AA15DFAC720A0C42",
+        "44A45DA3067F882BB4D87D6A48F9681E",
+        "555555555555",
     );
 
     let response = get_test_sms_client()
@@ -456,9 +447,9 @@ async fn resend_pin_over_sms() {
 #[tokio::test]
 async fn send_pin_over_voice() {
     let request_body = SendPinOverVoiceRequestBody::new(
-        "02CC3CAAFD733136AA15DFAC720A0C42".to_string(),
-        "44A45DA3067F882BB4D87D6A48F9681E".to_string(),
-        "523311800428".to_string(),
+        "02CC3CAAFD733136AA15DFAC720A0C42",
+        "44A45DA3067F882BB4D87D6A48F9681E",
+        "555555555555",
     );
 
     let response = get_test_sms_client()
@@ -487,7 +478,7 @@ async fn resend_pin_over_voice() {
 #[ignore]
 #[tokio::test]
 async fn verify_phone_number() {
-    let request_body = VerifyPhoneNumberRequestBody::new("123456".to_string());
+    let request_body = VerifyPhoneNumberRequestBody::new("123456");
 
     let response = get_test_sms_client()
         .verify_phone_number("AAA30929B83F2ED86CC34781BCB7A546", request_body)
@@ -501,7 +492,7 @@ async fn verify_phone_number() {
 #[ignore]
 #[tokio::test]
 async fn get_tfa_verification_status() {
-    let query_parameters = GetTfaVerificationStatusQueryParameters::new("523311800428".to_string());
+    let query_parameters = GetTfaVerificationStatusQueryParameters::new("555555555555");
     let response = get_test_sms_client()
         .get_tfa_verification_status("02CC3CAAFD733136AA15DFAC720A0C42", query_parameters)
         .await

--- a/tests/whatsapp.rs
+++ b/tests/whatsapp.rs
@@ -33,9 +33,9 @@ fn get_test_sender_number() -> String {
 #[tokio::test]
 async fn send_text() {
     let request_body = SendTextRequestBody::new(
-        get_test_sender_number(),
-        get_test_destination_number(),
-        TextContent::new(DUMMY_TEXT.to_string()),
+        &get_test_sender_number(),
+        &get_test_destination_number(),
+        TextContent::new(DUMMY_TEXT),
     );
 
     let response = get_test_wa_client().send_text(request_body).await.unwrap();
@@ -48,11 +48,10 @@ async fn send_text() {
 #[tokio::test]
 async fn send_document() {
     let request_body = SendDocumentRequestBody::new(
-        get_test_sender_number(),
-        get_test_destination_number(),
+        &get_test_sender_number(),
+        &get_test_destination_number(),
         DocumentContent::new(
-            "https://perso.limsi.fr/pointal/_media/python:cours:mementopython3-english.pdf"
-                .to_string(),
+            "https://perso.limsi.fr/pointal/_media/python:cours:mementopython3-english.pdf",
         ),
     );
 
@@ -69,9 +68,9 @@ async fn send_document() {
 #[tokio::test]
 async fn send_image() {
     let request_body = SendImageRequestBody::new(
-        get_test_sender_number(),
-        get_test_destination_number(),
-        ImageContent::new("https://rustacean.net/assets/rustacean-flat-happy.png".to_string()),
+        &get_test_sender_number(),
+        &get_test_destination_number(),
+        ImageContent::new("https://rustacean.net/assets/rustacean-flat-happy.png"),
     );
 
     let response = get_test_wa_client().send_image(request_body).await.unwrap();
@@ -84,9 +83,9 @@ async fn send_image() {
 #[tokio::test]
 async fn send_audio() {
     let request_body = SendAudioRequestBody::new(
-        get_test_sender_number(),
-        get_test_destination_number(),
-        AudioContent::new("https://download.samplelib.com/mp3/sample-3s.mp3".to_string()),
+        &get_test_sender_number(),
+        &get_test_destination_number(),
+        AudioContent::new("https://download.samplelib.com/mp3/sample-3s.mp3"),
     );
 
     let response = get_test_wa_client().send_audio(request_body).await.unwrap();
@@ -99,9 +98,9 @@ async fn send_audio() {
 #[tokio::test]
 async fn send_video() {
     let request_body = SendVideoRequestBody::new(
-        get_test_sender_number(),
-        get_test_destination_number(),
-        VideoContent::new("https://download.samplelib.com/mp4/sample-5s.mp4".to_string()),
+        &get_test_sender_number(),
+        &get_test_destination_number(),
+        VideoContent::new("https://download.samplelib.com/mp4/sample-5s.mp4"),
     );
 
     let response = get_test_wa_client().send_video(request_body).await.unwrap();
@@ -114,9 +113,9 @@ async fn send_video() {
 #[tokio::test]
 async fn send_sticker() {
     let request_body = SendStickerRequestBody::new(
-        get_test_sender_number(),
-        get_test_destination_number(),
-        StickerContent::new("https://www.gstatic.com/webp/gallery/1.webp".to_string()),
+        &get_test_sender_number(),
+        &get_test_destination_number(),
+        StickerContent::new("https://www.gstatic.com/webp/gallery/1.webp"),
     );
 
     let response = get_test_wa_client()
@@ -131,8 +130,8 @@ async fn send_sticker() {
 #[tokio::test]
 async fn send_location() {
     let request_body = SendLocationRequestBody::new(
-        get_test_sender_number(),
-        get_test_destination_number(),
+        &get_test_sender_number(),
+        &get_test_destination_number(),
         LocationContent::new(0.0, 0.0),
     );
 
@@ -147,10 +146,10 @@ async fn send_location() {
 #[ignore]
 #[tokio::test]
 async fn send_contact() {
-    let contact = Contact::new(ContactName::new("John".to_string(), "John Doe".to_string()));
+    let contact = Contact::new(ContactName::new("John", "John Doe"));
     let request_body = SendContactRequestBody::new(
-        get_test_sender_number(),
-        get_test_destination_number(),
+        &get_test_sender_number(),
+        &get_test_destination_number(),
         ContactContent::new(vec![contact]),
     );
 
@@ -165,12 +164,12 @@ async fn send_contact() {
 #[ignore]
 #[tokio::test]
 async fn send_interactive_buttons() {
-    let button = InteractiveButton::new_reply_button("1".to_string(), "Button Title".to_string());
+    let button = InteractiveButton::new_reply_button("1", "Button Title");
     let request_body = SendInteractiveButtonsRequestBody::new(
-        get_test_sender_number(),
-        get_test_destination_number(),
+        &get_test_sender_number(),
+        &get_test_destination_number(),
         InteractiveButtonsContent::new(
-            InteractiveBody::new("Hello".to_string()),
+            InteractiveBody::new("Hello"),
             InteractiveButtonsAction::new(vec![button]),
         ),
     );
@@ -187,16 +186,16 @@ async fn send_interactive_buttons() {
 #[ignore]
 #[tokio::test]
 async fn send_interactive_list() {
-    let row = InteractiveRow::new("1".to_string(), "Row Title".to_string());
+    let row = InteractiveRow::new("1", "Row Title");
 
     let section = InteractiveListSection::new(vec![row]);
 
     let request_body = SendInteractiveListRequestBody::new(
-        get_test_sender_number(),
-        get_test_destination_number(),
+        &get_test_sender_number(),
+        &get_test_destination_number(),
         InteractiveListContent::new(
-            InteractiveBody::new("Hello".to_string()),
-            InteractiveListAction::new("Section Title".to_string(), vec![section]),
+            InteractiveBody::new("Hello"),
+            InteractiveListAction::new("Section Title", vec![section]),
         ),
     );
 
@@ -213,12 +212,9 @@ async fn send_interactive_list() {
 #[tokio::test]
 async fn send_interactive_product() {
     let request_body = SendInteractiveProductRequestBody::new(
-        get_test_sender_number(),
-        get_test_destination_number(),
-        InteractiveProductContent::new(InteractiveProductAction::new(
-            "1".to_string(),
-            "2".to_string(),
-        )),
+        &get_test_sender_number(),
+        &get_test_destination_number(),
+        InteractiveProductContent::new(InteractiveProductAction::new("1", "2")),
     );
 
     let response = get_test_wa_client()
@@ -235,12 +231,12 @@ async fn send_interactive_product() {
 async fn send_interactive_multiproduct() {
     let section = InteractiveMultiproductSection::new(vec!["1".to_string(), "2".to_string()]);
     let request_body = SendInteractiveMultiproductRequestBody::new(
-        get_test_sender_number(),
-        get_test_destination_number(),
+        &get_test_sender_number(),
+        &get_test_destination_number(),
         InteractiveMultiproductContent::new(
-            InteractiveMultiproductHeader::new_text_header("Header text".to_string()),
-            InteractiveBody::new("Body text".to_string()),
-            InteractiveMultiproductAction::new("1".to_string(), vec![section]),
+            InteractiveMultiproductHeader::new_text_header("Header text"),
+            InteractiveBody::new("Body text"),
+            InteractiveMultiproductAction::new("1", vec![section]),
         ),
     );
 
@@ -256,16 +252,16 @@ async fn send_interactive_multiproduct() {
 #[ignore]
 #[tokio::test]
 async fn create_template() {
-    let structure = TemplateStructure::new(TemplateBody::new("hello".to_string()));
+    let structure = TemplateStructure::new(TemplateBody::new("hello"));
     let request_body = CreateTemplateRequestBody::new(
-        "rust_sdk_test_template".to_string(),
+        "rust_sdk_test_template",
         TemplateLanguage::EnUs,
         TemplateCategory::Marketing,
         structure,
     );
 
     let response = get_test_wa_client()
-        .create_template(get_test_sender_number(), request_body)
+        .create_template(&get_test_sender_number(), request_body)
         .await
         .unwrap();
 
@@ -277,7 +273,7 @@ async fn create_template() {
 #[tokio::test]
 async fn get_templates() {
     let response = get_test_wa_client()
-        .get_templates(get_test_sender_number())
+        .get_templates(&get_test_sender_number())
         .await
         .unwrap();
 
@@ -289,10 +285,7 @@ async fn get_templates() {
 #[tokio::test]
 async fn delete_template() {
     let status = get_test_wa_client()
-        .delete_template(
-            get_test_sender_number(),
-            "rust_sdk_test_template".to_string(),
-        )
+        .delete_template(&get_test_sender_number(), "rust_sdk_test_template")
         .await
         .unwrap();
 
@@ -303,13 +296,13 @@ async fn delete_template() {
 #[tokio::test]
 async fn send_template() {
     let template_content = TemplateContent::new(
-        "rust_sdk_test_template".to_string(),
+        "rust_sdk_test_template",
         TemplateData::new(TemplateBodyContent::new(vec!["hello".to_string()])),
-        TemplateLanguage::EnUs.to_string(),
+        &TemplateLanguage::EnUs.to_string(),
     );
     let message = FailoverMessage::new(
-        get_test_sender_number(),
-        get_test_destination_number(),
+        &get_test_sender_number(),
+        &get_test_destination_number(),
         template_content,
     );
 


### PR DESCRIPTION
This PR adds 2FA functionality and URL options for SMS. It also changes interfaces to use &str for more generic, concise usage.